### PR TITLE
Command line kgx io filters

### DIFF
--- a/bin/cli.py
+++ b/bin/cli.py
@@ -39,7 +39,6 @@ def cli(config, debug):
 @handle_exception
 def neo4j_download(config, uri, username, password, output, output_type, predicate_filter, subject_filter, object_filter, source_filter):
     t = kgx.NeoTransformer(uri=uri, username=username, password=password)
-    import pudb; pudb.set_trace()
     if predicate_filter != ():
         t.set_filter('predicate', predicate_filter)
     if subject_filter != ():

--- a/bin/cli.py
+++ b/bin/cli.py
@@ -27,16 +27,30 @@ def cli(config, debug):
 
 @cli.command(name='neo4j-download')
 @click.option('--output-type', type=str, help='Extention type of output files: ' + get_file_types())
+@click.option('--predicate-filter', type=str, multiple=True)
+@click.option('--subject-filter', type=str, multiple=True)
+@click.option('--object-filter', type=str, multiple=True)
+@click.option('--source-filter', type=str, multiple=True)
 @click.argument('uri', type=str)
 @click.argument('username', type=str)
 @click.argument('password', type=str)
 @click.argument('output', type=click.Path(exists=False))
 @pass_config
 @handle_exception
-def neo4j_download(config, uri, username, password, output, output_type):
-    neo_transformer = kgx.NeoTransformer(uri=uri, username=username, password=password)
-    neo_transformer.load()
-    transform_and_save(neo_transformer, output, output_type)
+def neo4j_download(config, uri, username, password, output, output_type, predicate_filter, subject_filter, object_filter, source_filter):
+    t = kgx.NeoTransformer(uri=uri, username=username, password=password)
+    import pudb; pudb.set_trace()
+    if predicate_filter != ():
+        t.set_filter('predicate', predicate_filter)
+    if subject_filter != ():
+        t.set_filter('subject_category', subject_filter)
+    if object_filter != ():
+        t.set_filter('object_category', object_filter)
+    if source_filter != ():
+        t.set_filter('source', source_filter)
+
+    t.load()
+    transform_and_save(t, output, output_type)
 
 @cli.command(name='neo4j-upload')
 @click.option('--input-type', type=str, help='Extention type of output files: ' + get_file_types())

--- a/bin/cli.py
+++ b/bin/cli.py
@@ -35,9 +35,7 @@ def cli(config, debug):
 @handle_exception
 def neo4j_download(config, uri, username, password, output, output_type):
     neo_transformer = kgx.NeoTransformer(uri=uri, username=username, password=password)
-
     neo_transformer.load()
-
     transform_and_save(neo_transformer, output, output_type)
 
 @cli.command(name='neo4j-upload')
@@ -66,49 +64,8 @@ def dump(config, inputs, output, input_type, output_type):
     INPUTS  : any number of files or endpoints
     OUTPUT : the output file
     """
-    if output_type is None:
-        output_type = get_type(output)
-
-    if input_type is None:
-        input_types = [get_type(i) for i in inputs]
-        for t in input_types:
-            if input_types[0] != t:
-                raise Exception("""Each input file must have the same file type.
-                    Try setting the --input-type parameter to enforce a single
-                    type."""
-                )
-            input_type = input_types[0]
-
-    input_transformer = get_transformer(input_type)
-
-    if input_transformer is None:
-        raise Exception('Inputs do not have a recognized type: ' + get_file_types())
-
-    t = input_transformer()
-
-    for i in inputs:
-        t.parse(i)
-
-    t.report()
-
-    output_transformer = get_transformer(output_type)
-
-    if output_transformer is None:
-        raise Exception('Output does not have a recognized type: ' + get_file_types())
-
-    kwargs = {
-        'extention' : output_type
-    }
-
-    w = output_transformer(t.graph)
-    result_path = w.save(output, **kwargs)
-
-    if result_path is not None and os.path.isfile(result_path):
-        click.echo("File created at: " + result_path)
-    elif os.path.isfile(output):
-        click.echo("File created at: " + output)
-    else:
-        click.echo("Could not create file.")
+    t = load_transformer(inputs, input_type)
+    transform_and_save(t, output, output_type)
 
 def transform_and_save(t:Transformer, output_path:str, output_type:str=None):
     """

--- a/bin/cli.py
+++ b/bin/cli.py
@@ -27,26 +27,18 @@ def cli(config, debug):
 
 @cli.command(name='neo4j-download')
 @click.option('--output-type', type=str, help='Extention type of output files: ' + get_file_types())
-@click.option('--predicate-filter', type=str, multiple=True)
-@click.option('--subject-filter', type=str, multiple=True)
-@click.option('--object-filter', type=str, multiple=True)
-@click.option('--source-filter', type=str, multiple=True)
+@click.option('--property-filter', type=(str, str), multiple=True)
 @click.argument('uri', type=str)
 @click.argument('username', type=str)
 @click.argument('password', type=str)
 @click.argument('output', type=click.Path(exists=False))
 @pass_config
 @handle_exception
-def neo4j_download(config, uri, username, password, output, output_type, predicate_filter, subject_filter, object_filter, source_filter):
+def neo4j_download(config, uri, username, password, output, output_type, property_filter):
     t = kgx.NeoTransformer(uri=uri, username=username, password=password)
-    if predicate_filter != ():
-        t.set_filter('predicate', predicate_filter)
-    if subject_filter != ():
-        t.set_filter('subject_category', subject_filter)
-    if object_filter != ():
-        t.set_filter('object_category', object_filter)
-    if source_filter != ():
-        t.set_filter('source', source_filter)
+
+    for key, value in property_filter:
+        t.set_filter(key, value)
 
     t.load()
     transform_and_save(t, output, output_type)

--- a/bin/cli.py
+++ b/bin/cli.py
@@ -26,7 +26,7 @@ def cli(config, debug):
         logging.basicConfig(level=logging.DEBUG)
 
 @cli.command(name='neo4j-download')
-@click.option('--output-type', type=str, help='Extention type of output files: ' + get_file_types())
+@click.option('--output-type', type=click.Choice(get_file_types()))
 @click.option('--property-filter', type=(str, str), multiple=True)
 @click.argument('uri', type=str)
 @click.argument('username', type=str)
@@ -44,7 +44,7 @@ def neo4j_download(config, uri, username, password, output, output_type, propert
     transform_and_save(t, output, output_type)
 
 @cli.command(name='neo4j-upload')
-@click.option('--input-type', type=str, help='Extention type of output files: ' + get_file_types())
+@click.option('--input-type', type=click.Choice(get_file_types()))
 @click.argument('uri', type=str)
 @click.argument('username', type=str)
 @click.argument('password', type=str)
@@ -57,8 +57,8 @@ def neo4j_upload(config, uri, username, password, inputs, input_type):
     neo_transformer.save()
 
 @cli.command()
-@click.option('--input-type', type=str, help='Extention type of input files: ' + get_file_types())
-@click.option('--output-type', type=str, help='Extention type of output files: ' + get_file_types())
+@click.option('--input-type', type=click.Choice(get_file_types()))
+@click.option('--output-type', type=click.Choice(get_file_types()))
 @click.argument('inputs', nargs=-1, type=click.Path(exists=False))
 @click.argument('output', type=click.Path(exists=False))
 @pass_config

--- a/kgx/cli/utils.py
+++ b/kgx/cli/utils.py
@@ -10,13 +10,11 @@ _transformers = {
     'rq' : kgx.SparqlTransformer
 }
 
-_file_types = ', '.join(_transformers.keys())
-
 def get_transformer(extention):
     return _transformers.get(extention)
 
 def get_file_types():
-    return _file_types
+    return _transformers.keys()
 
 def get_type(filename):
     for t in _transformers.keys():


### PR DESCRIPTION
- Partially resolves https://github.com/NCATS-Tangerine/kgx/issues/3
```shell
$ kgx neo4j-download --help
Usage: kgx neo4j-download [OPTIONS] URI USERNAME PASSWORD OUTPUT

Options:
  --output-type [tsv|graphml|rq|json|csv|ttl|txt]
  --property-filter <TEXT TEXT>...
  --help                          Show this message and exit.
```
The filters in `NeoTransformer.py` need some more work though:
```shell
$ kgx --debug neo4j-download --property-filter subject_category named_thing --property-filter object_category named_thing bolt://34.229.55.225:7687 neo4j ************ out2.json
DEBUG:root:MATCH (n:named_thing:named_thing ) RETURN n SKIP 0 LIMIT 1000;
DEBUG:root:MATCH (s)-[p ]->(o)
            RETURN s,p,o
            SKIP 0 LIMIT 1000;
File created at: out2.json
```