### PR TITLE
Fixed node set

### DIFF
--- a/kgx/neo_transformer.py
+++ b/kgx/neo_transformer.py
@@ -4,7 +4,10 @@ import logging, yaml
 import itertools
 from .transformer import Transformer
 
+from typing import Union
+
 from neo4j.v1 import GraphDatabase
+from neo4j.v1.types import Node, Record
 
 neo4j_log = logging.getLogger("neo4j.bolt")
 neo4j_log.setLevel(logging.WARNING)
@@ -70,11 +73,16 @@ class NeoTransformer(Transformer):
         for edge in edge_records:
             self.load_edge(edge)
 
-    def load_node(self, node_record):
+    def load_node(self, node_record:Union[Node, Record]):
         """
         Load node from a neo4j record
         """
-        node=node_record[0]
+        node = None
+        if isinstance(node_record, Node):
+            node = node_record
+        elif isinstance(node_record, Record):
+            node = node_record[0]
+
         attributes = {}
 
         for key, value in node.items():
@@ -108,6 +116,12 @@ class NeoTransformer(Transformer):
 
         if 'type' not in attributes:
             attributes['type'] = edge_predicate.type
+
+        if subject_id not in self.graph.nodes():
+            self.load_node(edge_subject)
+
+        if object_id not in self.graph.nodes():
+            self.load_node(edge_object)
 
         self.graph.add_edge(
             subject_id,


### PR DESCRIPTION
- Now that we can download a subset of the graph with a fitler,
  it's possible to download edges where one of the nodes is not
  in the node set. This fix ensures that every node in the edge
  set will also be present in the node set.

  Note: This makes the asymptotic behavior of load_edge significantly
        worse, since the connected nodes have to be found in the
        node set every time.

We will need to improve on this eventually. @cmungall, @deepakunni3  let me know if you think there's any best way to do this.