### PR TITLE
Fix uses of get_file_types

### DIFF
--- a/bin/translator_kgx.py
+++ b/bin/translator_kgx.py
@@ -118,7 +118,7 @@ def transform_and_save(t:Transformer, output_path:str, output_type:str=None):
     output_transformer = get_transformer(output_type)
 
     if output_transformer is None:
-        raise Exception('Output does not have a recognized type: ' + get_file_types())
+        raise Exception('Output does not have a recognized type: ' + str(get_file_types()))
 
     kwargs = {
         'extention' : output_type
@@ -152,7 +152,7 @@ def load_transformer(input_paths:List[str], input_type:str=None) -> Transformer:
     transformer_constructor = get_transformer(input_type)
 
     if transformer_constructor is None:
-        raise Exception('Inputs do not have a recognized type: ' + get_file_types())
+        raise Exception('Inputs do not have a recognized type: ' + str(get_file_types()))
 
     t = transformer_constructor()
 

--- a/kgx/cli/utils.py
+++ b/kgx/cli/utils.py
@@ -14,7 +14,7 @@ def get_transformer(extention):
     return _transformers.get(extention)
 
 def get_file_types():
-    return _transformers.keys()
+    return tuple(_transformers.keys())
 
 def get_type(filename):
     for t in _transformers.keys():


### PR DESCRIPTION
Previously, string concatenation was complaining about the use of
dict_keys.  Using str() fixes this, but leaves behind a dict_keys
signature in the string.  Also, it seems a collection is expected when
get_file_types() is used, so might as well convert it to a tuple.