### PR TITLE
Neo4j merge fix

### DIFF
--- a/bin/translator_kgx.py
+++ b/bin/translator_kgx.py
@@ -83,16 +83,20 @@ def neo4j_download(config, uri, username, password, output, output_type, propert
 
 @cli.command(name='neo4j-upload')
 @click.option('--input-type', type=click.Choice(get_file_types()))
+@click.option('--use-unwind', is_flag=True, help='Loads using UNWIND, which is quicker')
 @click.argument('uri', type=str)
 @click.argument('username', type=str)
 @click.argument('password', type=str)
 @click.argument('inputs', nargs=-1, type=click.Path(exists=False))
 @pass_config
 @handle_exception
-def neo4j_upload(config, uri, username, password, inputs, input_type):
+def neo4j_upload(config, uri, username, password, inputs, input_type, use_unwind):
     t = load_transformer(inputs, input_type)
     neo_transformer = kgx.NeoTransformer(graph=t.graph, uri=uri, username=username, password=password)
-    neo_transformer.save()
+    if use_unwind:
+        neo_transformer.save_with_unwind()
+    else:
+        neo_transformer.save()
 
 @cli.command()
 @click.option('--input-type', type=click.Choice(get_file_types()))


### PR DESCRIPTION
Fixes #61

Merging on a vector of properties would create a new object if that vector was not present in the database. Now, we are merging on a node id only, and upon creation we are setting the properties.

Also fixed a weird bug with a pandas Record's `__eq__` method throwing an exception when inputting `None`. Replaced equality comparison with identity comparison.

Note: if a node already exists then its properties will not be set, even if there are novel properties. Should we rather always set all properties?