### PR TITLE
Remap node and edge properties

### DIFF
--- a/kgx/neo_transformer.py
+++ b/kgx/neo_transformer.py
@@ -24,7 +24,8 @@ class NeoTransformer(Transformer):
     TODO: also support mapping from Monarch neo4j
     """
 
-    remap_properties = []
+    remap_node_properties = []
+    remap_edge_properties = []
 
     def __init__(self, graph=None, uri=None, username=None, password=None):
         super(NeoTransformer, self).__init__(graph)
@@ -102,8 +103,8 @@ class NeoTransformer(Transformer):
         if 'labels' not in attributes:
             attributes['labels'] = list(node.labels)
 
-        if len(self.remap_properties):
-            for pair in self.remap_properties:
+        if len(self.remap_node_properties):
+            for pair in self.remap_node_properties:
                 if pair[1] in attributes:
                     logging.debug("remap {} with {}".format(pair[0], pair[1]))
                     attributes[pair[0]] = attributes[pair[1]]
@@ -148,6 +149,14 @@ class NeoTransformer(Transformer):
 
         if object_id not in self.graph.nodes():
             self.load_node(edge_object)
+
+        if len(self.remap_edge_properties):
+            for pair in self.remap_edge_properties:
+                if pair[1] in attributes:
+                    logging.debug("remap {} with {}".format(pair[0], pair[1]))
+                    attributes[pair[0]] = attributes[pair[1]]
+                else:
+                    logging.warning("remap {} with {} failed; property {} missing from edge attributes".format(pair[0], pair[1], pair[1]))
 
         self.graph.add_edge(
             subject_id,

--- a/kgx/neo_transformer.py
+++ b/kgx/neo_transformer.py
@@ -24,6 +24,8 @@ class NeoTransformer(Transformer):
     TODO: also support mapping from Monarch neo4j
     """
 
+    remap_properties = []
+
     def __init__(self, graph=None, uri=None, username=None, password=None):
         super(NeoTransformer, self).__init__(graph)
 
@@ -100,8 +102,15 @@ class NeoTransformer(Transformer):
         if 'labels' not in attributes:
             attributes['labels'] = list(node.labels)
 
-        node_id = node['id'] if 'id' in node else node.id
+        if len(self.remap_properties):
+            for pair in self.remap_properties:
+                if pair[1] in attributes:
+                    logging.debug("remap {} with {}".format(pair[0], pair[1]))
+                    attributes[pair[0]] = attributes[pair[1]]
+                else:
+                    logging.warning("remap {} with {} failed; property {} missing from node attributes".format(pair[0], pair[1], pair[1]))
 
+        node_id = attributes['id'] if 'id' in attributes else node.id
         self.graph.add_node(node_id, attr_dict=attributes)
 
     def load_edge(self, edge_record):


### PR DESCRIPTION
@cmungall 

This PR adds the ability to remap the value of a node property with the value of another existing node property, on-the-fly when loading nodes from a connected local or remote Neo4j.

The most common use case is to remap the `id` property of a node with another defined node property.

Similarly for edge properties.

Usage:
```
    # initialize NeoTransformer
    n = NeoTransformer(None, uri, username, password)

    # add remap conditions
    n.remap_node_properties.append(("id", "alternate_id"))
    n.remap_edge_properties.append(("source", "is_defined_by"))

    # load
    n.load()

```


