### PR TITLE
Remap node property fix

### DIFF
--- a/kgx/neo_transformer.py
+++ b/kgx/neo_transformer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import networkx as nx
 import logging, yaml
-import itertools
+import itertools, uuid
 from .transformer import Transformer
 
 from typing import Union
@@ -108,6 +108,8 @@ class NeoTransformer(Transformer):
         """
         Load an edge from a neo4j record
         """
+
+        edge_key = str(uuid.uuid4())
         edge_subject = edge_record[0]
         edge_predicate = edge_record[1]
         edge_object = edge_record[2]
@@ -143,6 +145,7 @@ class NeoTransformer(Transformer):
         self.graph.add_edge(
             subject_id,
             object_id,
+            edge_key,
             attr_dict=attributes
         )
 

--- a/kgx/transformer.py
+++ b/kgx/transformer.py
@@ -70,23 +70,48 @@ class Transformer(object):
         graphs.insert(0, self.graph)
         self.graph = nx.compose_all(graphs, "mergedMultiDiGraph")
 
-    def remap_node_identifier(self, new_property):
+    def remap_node_identifier(self, type, new_property, prefix=None):
         """
         Remap node `id` attribute with value from node `new_property` attribute
 
         Parameters
         ----------
+        type: string
+            label referring to nodes whose id needs to be remapped
+
         new_property: string
-            new property name from which the value is pulled from
+            property name from which the new value is pulled from
+
+        prefix: string
+            signifies that the value for `new_property` is a list and the `prefix` indicates which value
+            to pick from the list
 
         """
         mapping = {}
         for node_id in self.graph.nodes_iter():
             node = self.graph.node[node_id]
+            if type not in node['labels']:
+                continue
             if new_property in node:
-                mapping[node_id] = node[new_property]
+                if prefix:
+                    # node[new_property] contains a list of values
+                    new_property_values = node[new_property]
+                    for v in new_property_values:
+                        if prefix in v:
+                            # take the first occurring value that contains the given prefix
+                            if 'HGNC:HGNC:' in v:
+                                # TODO: this is a temporary fix and must be removed later
+                                v = ':'.join(v.split(':')[1:])
+                            mapping[node_id] = v
+                            break
+                else:
+                    # node[new_property] contains a string value
+                    mapping[node_id] = node[new_property]
             else:
+                # node does not contain new_property key; fall back to original node 'id'
                 mapping[node_id] = node_id
+
+        nx.set_node_attributes(self.graph, values = mapping, name = 'id')
         nx.relabel_nodes(self.graph, mapping, copy=False)
 
         # update 'subject' of all outgoing edges
@@ -101,12 +126,15 @@ class Transformer(object):
             updated_object_values[edge] = edge[1]
         nx.set_edge_attributes(self.graph, values = updated_object_values, name = 'object')
 
-    def remap_node_property(self, old_property, new_property):
+    def remap_node_property(self, type, old_property, new_property):
         """
         Remap the value in node `old_property` attribute with value from node `new_property` attribute
 
         Parameters
         ----------
+        type: string
+            label referring to nodes whose property needs to be remapped
+
         old_property: string
             old property name whose value needs to be replaced
 
@@ -117,18 +145,23 @@ class Transformer(object):
         mapping = {}
         for node_id in self.graph.nodes_iter():
             node = self.graph.node[node_id]
+            if type not in node['labels']:
+                continue
             if new_property in node:
                 mapping[node_id] = node[new_property]
             elif old_property in node:
                 mapping[node_id] = node[old_property]
         nx.set_node_attributes(self.graph, values = mapping, name = old_property)
 
-    def remap_edge_property(self, old_property, new_property):
+    def remap_edge_property(self, type, old_property, new_property):
         """
         Remap the value in edge `old_property` attribute with value from edge `new_property` attribute
 
         Parameters
         ----------
+        type: string
+            label referring to edges whose property needs to be remapped
+
         old_property: string
             old property name whose value needs to be replaced
 
@@ -140,6 +173,8 @@ class Transformer(object):
         for edge in self.graph.edges_iter(data=True, keys=True):
             edge_key = edge[0:3]
             edge_data = edge[3]
+            if type not in edge_data['edge_label']:
+                continue
             if new_property in edge_data:
                 mapping[edge_key] = edge_data[new_property]
             else:

--- a/kgx/transformer.py
+++ b/kgx/transformer.py
@@ -70,6 +70,82 @@ class Transformer(object):
         graphs.insert(0, self.graph)
         self.graph = nx.compose_all(graphs, "mergedMultiDiGraph")
 
+    def remap_node_identifier(self, new_property):
+        """
+        Remap node `id` attribute with value from node `new_property` attribute
+
+        Parameters
+        ----------
+        new_property: string
+            new property name from which the value is pulled from
+
+        """
+        mapping = {}
+        for node_id in self.graph.nodes_iter():
+            node = self.graph.node[node_id]
+            if new_property in node:
+                mapping[node_id] = node[new_property]
+            else:
+                mapping[node_id] = node_id
+        nx.relabel_nodes(self.graph, mapping, copy=False)
+
+        # update 'subject' of all outgoing edges
+        updated_subject_values = {}
+        for edge in self.graph.out_edges(keys=True):
+            updated_subject_values[edge] = edge[0]
+        nx.set_edge_attributes(self.graph, values = updated_subject_values, name = 'subject')
+
+        # update 'object' of all incoming edges
+        updated_object_values = {}
+        for edge in self.graph.in_edges(keys=True):
+            updated_object_values[edge] = edge[1]
+        nx.set_edge_attributes(self.graph, values = updated_object_values, name = 'object')
+
+    def remap_node_property(self, old_property, new_property):
+        """
+        Remap the value in node `old_property` attribute with value from node `new_property` attribute
+
+        Parameters
+        ----------
+        old_property: string
+            old property name whose value needs to be replaced
+
+        new_property: string
+            new property name from which the value is pulled from
+
+        """
+        mapping = {}
+        for node_id in self.graph.nodes_iter():
+            node = self.graph.node[node_id]
+            if new_property in node:
+                mapping[node_id] = node[new_property]
+            elif old_property in node:
+                mapping[node_id] = node[old_property]
+        nx.set_node_attributes(self.graph, values = mapping, name = old_property)
+
+    def remap_edge_property(self, old_property, new_property):
+        """
+        Remap the value in edge `old_property` attribute with value from edge `new_property` attribute
+
+        Parameters
+        ----------
+        old_property: string
+            old property name whose value needs to be replaced
+
+        new_property: string
+            new property name from which the value is pulled from
+
+        """
+        mapping = {}
+        for edge in self.graph.edges_iter(data=True, keys=True):
+            edge_key = edge[0:3]
+            edge_data = edge[3]
+            if new_property in edge_data:
+                mapping[edge_key] = edge_data[new_property]
+            else:
+                mapping[edge_key] = edge_data[old_property]
+        nx.set_edge_attributes(self.graph, values = mapping, name = old_property)
+
     @staticmethod
     def dump(G):
         """


### PR DESCRIPTION
This PR adds the ability to remap the value of a node property with the value of another existing node property.

The modifications are done on the in-memory networkx graph.

The most common use case is to remap the `id` property of a node with another defined node property. This can be achieved by `remap_node_identifier()` method.

For all other properties use `remap_node_property()` method.

Similarly, use `remap_edge_property()` method for edges.

Usage:
```
# initialize NeoTransformer
n = NeoTransformer(None, uri, username, password)

# load Neo4j graph (or sub-graph) into memory
n.load()

# remap node 'id' with 'alt_id' for nodes of type 'gene'
n.remap_node_identifier('gene', 'alt_id')

# for nodes of type 'gene', add a 'description' property to node with its value from 'definition' property
n.remap_node_property('gene', 'description', 'definition')

# for edges of type 'contributes_to', add a 'source' property to edge with its value from 'is_defined_by' property
n.remap_edge_property('contributes_to', 'source', 'is_defined_by')
```
