### PR TITLE
Fixed ObanRdfTransformer

### DIFF
--- a/bin/translator_kgx.py
+++ b/bin/translator_kgx.py
@@ -17,6 +17,10 @@ import pandas as pd
 
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
+def error(msg):
+    click.echo(msg)
+    quit()
+
 @click.group()
 @click.option('--debug', is_flag=True, help='Prints the stack trace if error occurs')
 @click.version_option(version=kgx.__version__, prog_name=kgx.__name__)
@@ -30,12 +34,15 @@ def cli(config, debug):
         logging.basicConfig(level=logging.DEBUG)
 
 @cli.command(name='node-summary')
-@click.argument('address', type=str)
-@click.argument('username', type=str)
-@click.argument('password', type=str)
-@click.option('--out', type=click.Path(exists=False))
+@click.option('-a', '--address', type=str, required=True)
+@click.option('-u', '--username', type=str, required=True)
+@click.option('-p', '--password', type=str, required=True)
+@click.option('-o', '--output', type=click.Path(exists=False))
 @pass_config
-def node_summary(config, address, username, password, out=None):
+def node_summary(config, address, username, password, output=None):
+    if output is not None and not is_writable(output):
+        error(f'Cannot write to {output}')
+
     bolt_driver = GraphDatabase.driver(address, auth=(username, password))
 
     query = """
@@ -56,7 +63,7 @@ def node_summary(config, address, username, password, out=None):
         elif category is None:
             continue
         else:
-            raise Exception('Unrecognized value for node.category: {}'.format(category))
+            error('Unrecognized value for node.category: {}'.format(category))
 
     rows = []
     with click.progressbar(categories, length=len(categories)) as bar:
@@ -83,19 +90,22 @@ def node_summary(config, address, username, password, out=None):
     df = pd.DataFrame(rows)
     df = df[['category', 'prefix', 'frequency']]
 
-    if out is None:
+    if output is None:
         click.echo(df)
     else:
-        df.to_csv(out, sep='|', header=True)
-        click.echo('Saved report to {}'.format(out))
+        df.to_csv(output, sep='|', header=True)
+        click.echo('Saved report to {}'.format(output))
 
 @cli.command(name='edge-summary')
-@click.argument('address', type=str)
-@click.argument('username', type=str)
-@click.argument('password', type=str)
-@click.option('--out', type=click.Path(exists=False))
+@click.option('-a', '--address', type=str, required=True)
+@click.option('-u', '--username', type=str, required=True)
+@click.option('-p', '--password', type=str, required=True)
+@click.option('-o', '--output', type=click.Path(exists=False))
 @pass_config
-def edge_summary(config, address, username, password, out=None):
+def edge_summary(config, address, username, password, output=None):
+    if output is not None and not is_writable(output):
+        error(f'Cannot write to {output}')
+
     bolt_driver = GraphDatabase.driver(address, auth=(username, password))
 
     query = """
@@ -116,7 +126,7 @@ def edge_summary(config, address, username, password, out=None):
         elif category is None:
             continue
         else:
-            raise Exception('Unrecognized value for node.category: {}'.format(category))
+            error('Unrecognized value for node.category: {}'.format(category))
 
     categories = list(categories)
 
@@ -155,12 +165,12 @@ def edge_summary(config, address, username, password, out=None):
     df = pd.DataFrame(rows)
     df = df[['subject_category', 'subject_prefix', 'object_category', 'object_prefix', 'frequency']]
 
-    if out is None:
+    if output is None:
         with pd.option_context('display.max_rows', None, 'display.max_columns', None):
             click.echo(df)
     else:
-        df.to_csv(out, sep='|', header=True)
-        click.echo('Saved report to {}'.format(out))
+        df.to_csv(output, sep='|', header=True)
+        click.echo('Saved report to {}'.format(output))
 
 @cli.command()
 @click.option('--input-type', type=click.Choice(get_file_types()))
@@ -173,39 +183,22 @@ def validate(config, inputs, input_type):
     click.echo(result)
 
 @cli.command(name='neo4j-download')
-@click.option('-o', '--output-type', type=click.Choice(get_file_types()))
+@click.option('--output-type', type=click.Choice(get_file_types()))
 @click.option('-d', '--directed', is_flag=True, help='Enforces subject -> object edge direction')
 @click.option('-lb', '--labels', type=(click.Choice(FilterLocation.values()), str), multiple=True, help='For filtering on labels. CHOICE: {}'.format(', '.join(FilterLocation.values())))
 @click.option('-pr', '--properties', type=(click.Choice(FilterLocation.values()), str, str), multiple=True, help='For filtering on properties (key value pairs). CHOICE: {}'.format(', '.join(FilterLocation.values())))
-@click.argument('address', type=str)
+@click.option('-a', '--address', type=str, required=True)
 @click.option('-u', '--username', type=str)
 @click.option('-p', '--password', type=str)
 @click.option('--start', type=int, default=0)
 @click.option('--end', type=int)
-@click.argument('output', type=click.Path(exists=False))
+@click.option('-o', '--output', type=click.Path(exists=False), required=True)
 @pass_config
 def neo4j_download(config, address, username, password, output, output_type, labels, properties, directed, start, end):
     if not is_writable(output):
-        raise Exception(f'Cannot write to {output}')
+        error(f'Cannot write to {output}')
 
-    o = urlparse(address)
-
-    if o.password is None and password is None:
-        raise Exception('Could not extract the password from the address, please set password argument')
-    elif password is None:
-        password = o.password
-
-    if o.username is None and username is None:
-        raise Exception('Could not extract the username from the address, please set username argument')
-    elif username is None:
-        username = o.username
-
-    t = kgx.NeoTransformer(
-        host=o.hostname,
-        ports={o.scheme : o.port},
-        username=username,
-        password=password
-    )
+    t = make_neo4j_transformer(address, username, password)
 
     set_transformer_filters(transformer=t, labels=labels, properties=properties)
 
@@ -226,17 +219,40 @@ def set_transformer_filters(transformer:Transformer, labels:list, properties:lis
         target = '{}_property'.format(location)
         transformer.set_filter(target=target, value=(property_name, property_value))
 
+def make_neo4j_transformer(address, username, password):
+    o = urlparse(address)
+
+    if o.password is None and password is None:
+        error('Could not extract the password from the address, please set password argument')
+    elif password is None:
+        password = o.password
+
+    if o.username is None and username is None:
+        error('Could not extract the username from the address, please set username argument')
+    elif username is None:
+        username = o.username
+
+    return kgx.NeoTransformer(
+        host=o.hostname,
+        ports={o.scheme : o.port},
+        username=username,
+        password=password
+    )
+
 @cli.command(name='neo4j-upload')
 @click.option('--input-type', type=click.Choice(get_file_types()))
 @click.option('--use-unwind', is_flag=True, help='Loads using UNWIND, which is quicker')
-@click.argument('address', type=str)
-@click.argument('username', type=str)
-@click.argument('password', type=str)
+@click.option('-a', '--address', type=str, required=True)
+@click.option('-u', '--username', type=str)
+@click.option('-p', '--password', type=str)
 @click.argument('inputs', nargs=-1, type=click.Path(exists=False), required=True)
 @pass_config
 def neo4j_upload(config, address, username, password, inputs, input_type, use_unwind):
     t = load_transformer(inputs, input_type)
-    neo_transformer = kgx.NeoTransformer(graph=t.graph, uri=address, username=username, password=password)
+
+    neo_transformer = make_neo4j_transformer(address, username, password)
+    neo_transformer.graph = t.graph
+
     if use_unwind:
         neo_transformer.save_with_unwind()
     else:
@@ -247,7 +263,7 @@ def neo4j_upload(config, address, username, password, inputs, input_type, use_un
 @click.option('--output-type', type=click.Choice(get_file_types()))
 @click.option('--mapping', type=str)
 @click.option('--preserve', is_flag=True)
-@click.option('-i', '--inputs', type=click.Path(exists=True), multiple=True)
+@click.argument('inputs', nargs=-1, type=click.Path(exists=False), required=True)
 @click.option('-o', '--output', type=click.Path(exists=False))
 @pass_config
 def dump(config, inputs, output, input_type, output_type, mapping, preserve):
@@ -255,7 +271,7 @@ def dump(config, inputs, output, input_type, output_type, mapping, preserve):
     Transforms a knowledge graph from one representation to another
     """
     if not is_writable(output):
-        raise Exception(f'Cannot write to {output}')
+        error(f'Cannot write to {output}')
 
     t = load_transformer(inputs, input_type)
     if mapping != None:
@@ -351,7 +367,7 @@ def transform_and_save(t:Transformer, output_path:str, output_type:str=None):
     output_transformer = get_transformer(output_type)
 
     if output_transformer is None:
-        raise Exception('Output does not have a recognized type: ' + str(get_file_types()))
+        error('Output does not have a recognized type: ' + str(get_file_types()))
 
     kwargs = {
         'extention' : output_type
@@ -365,7 +381,7 @@ def transform_and_save(t:Transformer, output_path:str, output_type:str=None):
     elif os.path.isfile(output_path):
         click.echo("File created at: " + output_path)
     else:
-        click.echo("Could not create file.")
+        error("Could not create file.")
 
 def load_transformer(input_paths:List[str], input_type:str=None) -> Transformer:
     """
@@ -376,16 +392,19 @@ def load_transformer(input_paths:List[str], input_type:str=None) -> Transformer:
         input_types = [get_type(i) for i in input_paths]
         for t in input_types:
             if input_types[0] != t:
-                raise Exception("""Each input file must have the same file type.
-                    Try setting the --input-type parameter to enforce a single
-                    type."""
+                error(
+                """\b
+                Each input file must have the same file type.
+                Try setting the --input-type parameter to enforce a single
+                type.
+                """
                 )
             input_type = input_types[0]
 
     transformer_constructor = get_transformer(input_type)
 
     if transformer_constructor is None:
-        raise Exception('Inputs do not have a recognized type: ' + str(get_file_types()))
+        error('Inputs do not have a recognized type: ' + str(get_file_types()))
 
     t = transformer_constructor()
     for i in input_paths:

--- a/kgx/cli/utils.py
+++ b/kgx/cli/utils.py
@@ -1,4 +1,4 @@
-import kgx
+import kgx, os, pathlib
 
 _transformers = {
     'txt' : kgx.PandasTransformer,
@@ -9,6 +9,20 @@ _transformers = {
     'json' : kgx.JsonTransformer,
     'rq' : kgx.SparqlTransformer
 }
+
+def is_writable(filepath):
+    """
+    Checks that the filepath is writable, creating a directory tree if requried
+    """
+    output = os.path.abspath(filepath)
+    dirname = os.path.dirname(filepath)
+
+    pathlib.Path(dirname).mkdir(parents=True, exist_ok=True)
+
+    is_writable = os.access(output, os.W_OK)
+    is_creatable = not os.path.isfile(output) and os.access(dirname, os.W_OK)
+
+    return is_writable or is_creatable
 
 def get_transformer(extention):
     return _transformers.get(extention)

--- a/kgx/rdf_transformer.py
+++ b/kgx/rdf_transformer.py
@@ -73,7 +73,7 @@ class RdfTransformer(Transformer):
         for nid in G.nodes():
             n = G.node[nid]
             if 'iri' not in n:
-                logging.warn("Expected IRI for {}".format(n))
+                logging.warning("Expected IRI for {}".format(n))
                 continue
             iri = URIRef(n['iri'])
             npmap = {}
@@ -102,8 +102,8 @@ class ObanRdfTransformer(RdfTransformer):
     inv_cmap = {}
     cmap = {}
 
-    def __init__(self, graph, **args):
-        super().__init__(graph, **args)
+    def __init__(self, graph=None):
+        super().__init__(graph)
         # Generate the map and the inverse map from default curie maps, which will be used later.
         for cmap in default_curie_maps:
             for k, v in cmap.items():
@@ -254,7 +254,7 @@ class RdfOwlTransformer(RdfTransformer):
                 for x in rg.objects( o, OWL.someValuesFrom ):
                     parent = x
                 if pred is None or parent is None:
-                    logging.warn("Do not know how to handle: {}".format(o))
+                    logging.warning("Do not know how to handle: {}".format(o))
             else:
                 # C SubClassOf D (C and D are named classes)
                 pred = 'owl:subClassOf'

--- a/kgx/rdf_transformer.py
+++ b/kgx/rdf_transformer.py
@@ -102,8 +102,8 @@ class ObanRdfTransformer(RdfTransformer):
     inv_cmap = {}
     cmap = {}
 
-    def __init__(self, **args):
-        super().__init__(**args)
+    def __init__(self, graph, **args):
+        super().__init__(graph, **args)
         # Generate the map and the inverse map from default curie maps, which will be used later.
         for cmap in default_curie_maps:
             for k, v in cmap.items():
@@ -152,7 +152,7 @@ class ObanRdfTransformer(RdfTransformer):
             uri = self.prefix_manager.expand(id)
         return URIRef(uri)
 
-    def save(self, filename: str = None, output_format: str = None):
+    def save(self, filename: str = None, output_format: str = None, **kwargs):
         """
         Transform the internal graph into the RDF graphs that follow OBAN-style modeling and dump into the file.
         """
@@ -262,4 +262,3 @@ class RdfOwlTransformer(RdfTransformer):
             obj['predicate'] = pred
             obj['provided_by'] = self.graph_metadata['provided_by']
             self.add_edge(parent, s, attr_dict=obj)
-


### PR DESCRIPTION
- Neo4jTransformer no longer sets an edge id with the database id
- Added start and end parameters to neo4j-download command, and when
  they are given end - start is taken to be the progress bar count.
- Added a utility method to ensure a filepath is writeable, and to
  create the directory tree if needed

Try it out with: (Note: set the password)
```
kgx neo4j-download -a bolt://neo4j:<password>@34.229.55.225:7687 -o out/gene.json --end 5000 -lb subject gene
kgx neo4j-download -a bolt://neo4j:<password>@34.229.55.225:7687 -o out/cell.json --end 5000 -lb subject cell
kgx dump out/gene.json out/cell.json -o out/out.ttl
```