### PR TITLE
Update networkx from 1.11 to 2.2

### DIFF
--- a/kgx/json_transformer.py
+++ b/kgx/json_transformer.py
@@ -31,11 +31,11 @@ class JsonTransformer(PandasTransformer):
     def export(self):
         nodes=[]
         edges=[]
-        for id,data in self.graph.nodes_iter(data=True):
+        for id,data in self.graph.nodes(data=True):
             node = data.copy()
             node['id'] = id
             nodes.append(node)
-        for o,s,data in self.graph.edges_iter(data=True):
+        for o,s,data in self.graph.edges(data=True):
             edge = data.copy()
             edge['subject'] = s
             edge['object'] = o

--- a/kgx/kgx_pandas.py
+++ b/kgx/kgx_pandas.py
@@ -27,7 +27,7 @@ class PandasTransformer(Transformer):
             
     def load_node(self, obj):
         id = obj['id']
-        self.graph.add_node(id, attr_dict=obj)
+        self.graph.add_node(id, **obj)
             
     def load_edges(self, df):
         for _,row in df.iterrows():
@@ -36,5 +36,5 @@ class PandasTransformer(Transformer):
     def load_edge(self, obj):
         s = obj['subject']
         o = obj['object']
-        self.graph.add_node(o, s, attr_dict=obj)
+        self.graph.add_node(o, s, **obj)
             

--- a/kgx/logicterm_transformer.py
+++ b/kgx/logicterm_transformer.py
@@ -21,13 +21,13 @@ class LogicTermTransformer(Transformer):
     
     def export_nodes(self) -> pd.DataFrame:
         items = []
-        for n,data in self.graph.nodes_iter(data=True):
+        for n,data in self.graph.nodes(data=True):
             for k,v in data.items():
                 self.write_term('node_prop', n, k, v)
 
     def export_edges(self) -> pd.DataFrame:
         items = []
-        for o,s,data in self.graph.edges_iter(data=True):
+        for o,s,data in self.graph.edges(data=True):
             el = data.get('edge_label', None)
             self.write_term('edge', el, o, s)
             for k,v in data.items():

--- a/kgx/mapper.py
+++ b/kgx/mapper.py
@@ -2,11 +2,11 @@ import networkx as nx
 
 def map_graph(G, mapping, preserve=True):
     if preserve:
-        for nid in G.nodes_iter():
+        for nid in G.nodes():
             if nid in mapping:
                 # add_node will append attributes
                 G.add_node(nid, source_curie=nid)
-        for oid,sid in G.edges_iter():
+        for oid,sid in G.edges():
             if oid in mapping:
                 for ex in G[oid][sid]:
                     G[oid][sid][ex].update(source_object=oid)

--- a/kgx/neo_transformer.py
+++ b/kgx/neo_transformer.py
@@ -165,7 +165,7 @@ class NeoTransformer(Transformer):
 
         node_id = node['id'] if 'id' in node else node.id
 
-        self.graph.add_node(node_id, attr_dict=attributes)
+        self.graph.add_node(node_id, **attributes)
 
     def load_edge(self, edge_record):
         """
@@ -470,7 +470,7 @@ class NeoTransformer(Transformer):
         nodes_by_category = {}
         node_properties = []
         for n in self.graph.nodes():
-            node = self.graph.node[n]
+            node = self.graph.nodes[n]
             if 'id' not in node:
                 continue
 
@@ -484,7 +484,7 @@ class NeoTransformer(Transformer):
 
         edges_by_relationship_type = {}
         edge_properties = []
-        for n, nbrs in self.graph.adjacency_iter():
+        for n, nbrs in self.graph.adjacency():
             for nbr, eattr in nbrs.items():
                 for entry, adjitem in eattr.items():
                     if adjitem['predicate'] not in edges_by_relationship_type:
@@ -506,7 +506,7 @@ class NeoTransformer(Transformer):
 
         labels = {'Node'}
         for n in self.graph.nodes():
-            node = self.graph.node[n]
+            node = self.graph.nodes[n]
             if 'category' in node:
                 if isinstance(node['category'], list):
                     labels.update(node['category'])
@@ -516,11 +516,11 @@ class NeoTransformer(Transformer):
         with self.bolt_driver.session() as session:
             session.write_transaction(self.create_constraints, labels)
             for node_id in self.graph.nodes():
-                node_attributes = self.graph.node[node_id]
+                node_attributes = self.graph.nodes[node_id]
                 if 'id' not in node_attributes:
                     node_attributes['id'] = node_id
                 session.write_transaction(self.save_node, node_attributes)
-            for n, nbrs in self.graph.adjacency_iter():
+            for n, nbrs in self.graph.adjacency():
                 for nbr, eattr in nbrs.items():
                     for entry, adjitem in eattr.items():
                         session.write_transaction(self.save_edge, adjitem)
@@ -670,7 +670,7 @@ class NeoTransformer(Transformer):
         """
         FH = open(filename, "w")
         edges = []
-        for edge in self.graph.edges_iter(data=True, keys=True):
+        for edge in self.graph.edges(data=True, keys=True):
             edges.append(edge[3])
 
         FH.write(json.dumps(edges))

--- a/kgx/nx_transformer.py
+++ b/kgx/nx_transformer.py
@@ -19,7 +19,7 @@ class GraphMLTransformer(NetworkxTransformer):
         # As a workaround, we converts lists into comma-separated strings.
         # We use deepcopy to avoid modifying original self.graph object.
         dgraph = copy.deepcopy(self.graph)
-        for n, nbrs in dgraph.adjacency_iter():
+        for n, nbrs in dgraph.adjacency():
             for nbr, eattr in nbrs.items():
                 for entry, adjitem in eattr.items():
                     for prop_uri, obj_curies in adjitem.items():

--- a/kgx/pandas_transformer.py
+++ b/kgx/pandas_transformer.py
@@ -40,7 +40,7 @@ class PandasTransformer(Transformer):
 
     def load_node(self, obj: Dict):
         id = obj['id'] # type: str
-        self.graph.add_node(id, attr_dict=obj)
+        self.graph.add_node(id, **obj)
 
     def load_edges(self, df: pd.DataFrame):
         for obj in df.to_dict('record'):
@@ -49,11 +49,11 @@ class PandasTransformer(Transformer):
     def load_edge(self, obj: Dict):
         s = obj['subject'] # type: str
         o = obj['object'] # type: str
-        self.graph.add_edge(o, s, attr_dict=obj)
+        self.graph.add_edge(o, s, **obj)
 
     def export_nodes(self) -> pd.DataFrame:
         items = []
-        for n,data in self.graph.nodes_iter(data=True):
+        for n,data in self.graph.nodes(data=True):
             item = data.copy()
             item['id'] = n
             items.append(item)
@@ -62,7 +62,7 @@ class PandasTransformer(Transformer):
 
     def export_edges(self) -> pd.DataFrame:
         items = []
-        for o,s,data in self.graph.edges_iter(data=True):
+        for o,s,data in self.graph.edges(data=True):
             item = data.copy()
             item['subject'] = s
             item['object'] = o

--- a/kgx/rdf_transformer.py
+++ b/kgx/rdf_transformer.py
@@ -70,8 +70,7 @@ class RdfTransformer(Transformer):
 
     def load_nodes(self, rg: rdflib.Graph):
         G = self.graph
-        for nid in G.nodes():
-            n = G.node[nid]
+        for n in G.nodes(data=True):
             if 'iri' not in n:
                 logging.warning("Expected IRI for {}".format(n))
                 continue
@@ -82,7 +81,7 @@ class RdfTransformer(Transformer):
                     if p in rmapping:
                         p = rmapping[p]
                     npmap[p] = str(o)
-            G.add_node(nid, **npmap)
+            G.add_node(n, **npmap)
 
     def load_edges(self, rg: rdflib.Graph):
         pass
@@ -92,7 +91,7 @@ class RdfTransformer(Transformer):
         oid = self.curie(o)
         self.graph.add_node(sid, iri=str(s))
         self.graph.add_node(oid, iri=str(o))
-        self.graph.add_edge(oid, sid, attr_dict=attr_dict)
+        self.graph.add_edge(oid, sid, **attr_dict)
 
 class ObanRdfTransformer(RdfTransformer):
     """
@@ -136,7 +135,7 @@ class ObanRdfTransformer(RdfTransformer):
             obj['provided_by'] = self.graph_metadata['provided_by']
             for each_s in s:
                 for each_o in o:
-                    self.graph.add_edge(each_o, each_s, attr_dict=obj)
+                    self.graph.add_edge(each_o, each_s, **obj)
 
     def curie(self, uri: UriString) -> str:
         curies = contract_uri(str(uri))
@@ -167,7 +166,7 @@ class ObanRdfTransformer(RdfTransformer):
 
         # Using an iterator of (node, adjacency dict) tuples for all nodes,
         # we iterate every edge (only outgoing adjacencies)
-        for n, nbrs in self.graph.adjacency_iter():
+        for n, nbrs in self.graph.adjacency():
             a_object = n
             for nbr, eattr in nbrs.items():
                 a_subject = nbr

--- a/kgx/transformer.py
+++ b/kgx/transformer.py
@@ -84,8 +84,8 @@ class Transformer(object):
 
         """
         mapping = {}
-        for node_id in self.graph.nodes_iter():
-            node = self.graph.node[node_id]
+        for node_id in self.graph.nodes():
+            node = self.graph.nodes[node_id]
             if type not in node['category']:
                 continue
             if new_property in node:
@@ -139,8 +139,8 @@ class Transformer(object):
 
         """
         mapping = {}
-        for node_id in self.graph.nodes_iter():
-            node = self.graph.node[node_id]
+        for node_id in self.graph.nodes():
+            node = self.graph.nodes[node_id]
             if type not in node['category']:
                 continue
             if new_property in node:
@@ -166,7 +166,7 @@ class Transformer(object):
 
         """
         mapping = {}
-        for edge in self.graph.edges_iter(data=True, keys=True):
+        for edge in self.graph.edges(data=True, keys=True):
             edge_key = edge[0:3]
             edge_data = edge[3]
             if type not in edge_data['edge_label']:

--- a/kgx/validator.py
+++ b/kgx/validator.py
@@ -25,9 +25,9 @@ class Validator(object):
 
         Test all node and edge properties plus relationship types are declared
         """
-        for nid,ad in G.nodes_iter(data=True):
+        for nid,ad in G.nodes(data=True):
             self.validate_node(nid, ad)
-        for oid,sid,ad in G.edges_iter(data=True):
+        for oid,sid,ad in G.edges(data=True):
             self.validate_edge(G, oid, sid, ad)
 
     def validate_node(self, nid, ad):
@@ -108,8 +108,8 @@ class Validator(object):
         fn = lambda: 'in_subset' in slot and 'translator_minimal' in slot['in_subset']
         self.test(fn, edge_label, 'edge label not in minimal list')
 
-        object_category = G.node[oid]['category']
-        subject_category = G.node[sid]['category']
+        object_category = G.nodes[oid]['category']
+        subject_category = G.nodes[sid]['category']
 
         if slot.domain is not None:
             if slot.domain != subject_category:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 prefixcommons>=0.1.4
 pip>=9.0.1
-networkx==1.11
+networkx==2.2
 SPARQLWrapper==1.8.0
 pandas<0.21
 pytest>=0.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 requires = [
     "prefixcommons>=0.1.4",
-    "networkx==1.11",
+    "networkx==2.2",
     "SPARQLWrapper==1.8.0",
     "pandas<0.21",
     "pytest>=0.0",

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -27,8 +27,8 @@ def test_mapping():
     print("Mapped..")
     
     count = 0
-    for nid in G.nodes_iter():
-        src = G.node[nid]['source_curie']
+    for nid in G.nodes():
+        src = G.nodes[nid]['source_curie']
         assert nid.startswith("Y:")
         assert src.startswith("X:")
         count += 1

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -30,7 +30,7 @@ def test_load():
 
 def rename_all(G):
     m = {}
-    for nid in G.nodes_iter():
+    for nid in G.nodes():
         tid = nid.replace("X:","FOO:")
         m[nid] = tid
     print("Renaming...")


### PR DESCRIPTION
Updating from networkx 1.11 to 2.2 requires changing a few of the methods for accessing and iterating over node and edges.

