### PR TITLE
Improve TTL export from RdfTransformer 

### DIFF
--- a/bin/translator_kgx.py
+++ b/bin/translator_kgx.py
@@ -684,16 +684,14 @@ def load_and_merge(config: dict, load_config):
         else:
             logging.error("type {} not yet supported for KGX load-and-merge operation.".format(target['type']))
 
-    merged_transformer = Transformer()
     merged_graph = gm.merge_all_graphs([x.graph for x in transformers])
-    merged_transformer.graph = merged_graph
 
     destination = cfg['destination']
     if destination['type'] in ['csv', 'tsv', 'ttl', 'json', 'tar']:
-        destination_transformer = get_transformer(destination['type'])()
+        destination_transformer = get_transformer(destination['type'])(merged_graph)
         destination_transformer.save(destination['filename'])
     elif destination['type'] == 'neo4j':
-        destination_transformer = kgx.NeoTransformer(merged_transformer.graph, uri=destination['uri'], username=destination['username'], password=destination['password'])
+        destination_transformer = kgx.NeoTransformer(merged_graph, uri=destination['uri'], username=destination['username'], password=destination['password'])
         destination_transformer.save_with_unwind()
     else:
         logging.error("type {} not yet supported for KGX load-and-merge operation.".format(destination['type']))

--- a/kgx/operations/graph_merge.py
+++ b/kgx/operations/graph_merge.py
@@ -97,7 +97,7 @@ class GraphMerge(object):
             Whether or not to preserve conflicting properties
 
         """
-        logging.info(f"Adding all nodes from {g2.name} to {g1.name}")
+        logging.info(f"Adding {g2.number_of_nodes()} nodes from {g2.name} to {g1.name}")
         for n, data in g2.nodes(data=True):
             if n in g1.nodes():
                 self.merge_node(g1, n, data, preserve)
@@ -169,7 +169,7 @@ class GraphMerge(object):
             Whether or not to preserve conflicting properties
 
         """
-        logging.info(f"Adding all edges from {g2} to {g1}")
+        logging.info(f"Adding {g2.number_of_edges()} edges from {g2} to {g1}")
         for u, v, key, data in g2.edges(keys=True, data=True):
             if g1.has_edge(u, v, key):
                 self.merge_edge(g1, u, v, key, data, preserve)

--- a/kgx/prefix_manager.py
+++ b/kgx/prefix_manager.py
@@ -46,6 +46,12 @@ class PrefixManager(object):
         for k, v in m.items():
             if isinstance(v, str):
                 self.prefix_map[k] = v
+        if 'biolink' not in self.prefix_map:
+            self.prefix_map['biolink'] = self.prefix_map['@vocab']
+        if ':' in self.prefix_map:
+            logging.info(f"Replacing default prefix mapping from {self.prefix_map[':']} to 'www.example.org/UNKNOWN/'")
+        else:
+            self.prefix_map[':'] = 'www.example.org/UNKNOWN/'
 
         self.reverse_prefix_map = {y: x for x, y in self.prefix_map.items()}
 
@@ -94,7 +100,6 @@ class PrefixManager(object):
         """
         # always prioritize non-CURIE shortform
         curie = None
-        print(uri)
         if uri in self.reverse_prefix_map:
             curie = self.reverse_prefix_map[uri]
         else:
@@ -124,7 +129,7 @@ class PrefixManager(object):
             Whether or not the given string is a CURIE
 
         """
-        m = re.match(r"^[^ :]+:[^/ :]+$", s)
+        m = re.match(r"^[^ :]*:[^/ :]+$", s)
         return bool(m)
 
     @staticmethod

--- a/kgx/prefix_manager.py
+++ b/kgx/prefix_manager.py
@@ -42,8 +42,12 @@ class PrefixManager(object):
             Dictionary of prefix to URI mappings
 
         """
-        self.prefix_map = m
-        self.reverse_prefix_map = {y: x for x, y in m.items() if isinstance(y, str)}
+        self.prefix_map = {}
+        for k, v in m.items():
+            if isinstance(v, str):
+                self.prefix_map[k] = v
+
+        self.reverse_prefix_map = {y: x for x, y in self.prefix_map.items()}
 
     def expand(self, curie: str, fallback: bool = True) -> str:
         """
@@ -63,17 +67,10 @@ class PrefixManager(object):
             A URI corresponding to the CURIE
 
         """
-        uri = None
-        if curie in self.prefix_map:
-            uri = self.prefix_map[curie]
-            # TODO: prefixcommons.curie_util will not unfold objects in json-ld context
-            if isinstance(uri, str):
-                return uri
-        else:
-            uri = cu.expand_uri(curie, [self.prefix_map])
-            if uri == curie and fallback:
-                uri = cu.expand_uri(curie)
-        print("CURIE {} to IRI {}".format(curie, uri))
+        uri = cu.expand_uri(curie, [self.prefix_map])
+        if uri == curie and fallback:
+            uri = cu.expand_uri(curie)
+
         return uri
 
     def contract(self, uri: str, fallback: bool = True) -> str:

--- a/kgx/prefix_manager.py
+++ b/kgx/prefix_manager.py
@@ -51,6 +51,7 @@ class PrefixManager(object):
         if ':' in self.prefix_map:
             logging.info(f"Replacing default prefix mapping from {self.prefix_map[':']} to 'www.example.org/UNKNOWN/'")
         else:
+            # TODO: the Default URL should be configurable
             self.prefix_map[':'] = 'www.example.org/UNKNOWN/'
 
         self.reverse_prefix_map = {y: x for x, y in self.prefix_map.items()}

--- a/kgx/transformers/pandas_transformer.py
+++ b/kgx/transformers/pandas_transformer.py
@@ -139,7 +139,7 @@ class PandasTransformer(Transformer):
 
         """
         node = Transformer.validate_node(node)
-        kwargs = PandasTransformer._build_kwargs(node)
+        kwargs = PandasTransformer._build_kwargs(node.copy())
         if 'id' in kwargs:
             n = kwargs['id']
             self.graph.add_node(n, **kwargs)
@@ -192,7 +192,7 @@ class PandasTransformer(Transformer):
         rows = []
         for n, data in self.graph.nodes(data=True):
             data = self.validate_node(data)
-            row = PandasTransformer._build_export_row(data)
+            row = PandasTransformer._build_export_row(data.copy())
             row['id'] = n
             rows.append(row)
         df = pd.DataFrame.from_records(rows)
@@ -211,7 +211,7 @@ class PandasTransformer(Transformer):
         rows = []
         for s, o, data in self.graph.edges(data=True):
             data = self.validate_edge(data)
-            row = PandasTransformer._build_export_row(data)
+            row = PandasTransformer._build_export_row(data.copy())
             row['subject'] = s
             row['object'] = o
             rows.append(row)

--- a/kgx/transformers/pandas_transformer.py
+++ b/kgx/transformers/pandas_transformer.py
@@ -139,7 +139,7 @@ class PandasTransformer(Transformer):
 
         """
         node = Transformer.validate_node(node)
-        kwargs = PandasTransformer._build_kwargs(node.copy())
+        kwargs = PandasTransformer._build_kwargs(node)
         if 'id' in kwargs:
             n = kwargs['id']
             self.graph.add_node(n, **kwargs)
@@ -192,7 +192,7 @@ class PandasTransformer(Transformer):
         rows = []
         for n, data in self.graph.nodes(data=True):
             data = self.validate_node(data)
-            row = PandasTransformer._build_export_row(data.copy())
+            row = PandasTransformer._build_export_row(data)
             row['id'] = n
             rows.append(row)
         df = pd.DataFrame.from_records(rows)
@@ -211,7 +211,7 @@ class PandasTransformer(Transformer):
         rows = []
         for s, o, data in self.graph.edges(data=True):
             data = self.validate_edge(data)
-            row = PandasTransformer._build_export_row(data.copy())
+            row = PandasTransformer._build_export_row(data)
             row['subject'] = s
             row['object'] = o
             rows.append(row)

--- a/kgx/transformers/rdf_graph_mixin.py
+++ b/kgx/transformers/rdf_graph_mixin.py
@@ -24,11 +24,6 @@ class RdfGraphMixin(object):
 
     """
 
-    # TODO: use OBO IRI from biolink model context once https://github.com/biolink/biolink-model/issues/211 is resolved
-    OBO = Namespace('http://purl.obolibrary.org/obo/')
-    OBAN = Namespace(biolink_prefix_map['OBAN'])
-    PMID = Namespace(biolink_prefix_map['PMID'])
-    BIOLINK = Namespace('https://w3id.org/biolink/')
     DEFAULT_EDGE_LABEL = 'related_to'
 
     def __init__(self, source_graph: nx.MultiDiGraph = None):
@@ -38,6 +33,13 @@ class RdfGraphMixin(object):
             self.graph = nx.MultiDiGraph()
 
         self.graph_metadata = {}
+        self.prefix_manager = PrefixManager()
+        self.DEFAULT = Namespace(self.prefix_manager.prefix_map[':'])
+        # TODO: use OBO IRI from biolink model context once https://github.com/biolink/biolink-model/issues/211 is resolved
+        self.OBO = Namespace('http://purl.obolibrary.org/obo/')
+        self.OBAN = Namespace(self.prefix_manager.prefix_map['OBAN'])
+        self.PMID = Namespace(self.prefix_manager.prefix_map['PMID'])
+        self.BIOLINK = Namespace(self.prefix_manager.prefix_map['biolink'])
 
     def load_networkx_graph(self, rdfgraph: rdflib.Graph = None, predicates: Set[URIRef] = None, **kwargs) -> None:
         """


### PR DESCRIPTION
This PR address the following,
* Fixes TTL export from RdfTransformer by implementing a base `save()` method
* Consolidates configurations between RdfGraphMixin and RdfTransformer
* Fixes a bug in load-and-merge cli operation 
