### PR TITLE
Rename 'KGX CLI' to simply 'kgx'

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -1,4 +1,4 @@
 
 .. click:: bin.translator_kgx:cli
-   :prog: KGX CLI
+   :prog: kgx
    :show-nested:


### PR DESCRIPTION
Since  I think this is simply the name of the  command line interface  program for this system?