### PR TITLE
Swap OrderedSet for ordered-set

### DIFF
--- a/kgx/transformers/pandas_transformer.py
+++ b/kgx/transformers/pandas_transformer.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import logging
 import tarfile
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 
 from kgx.utils.kgx_utils import generate_edge_key
 from kgx.transformers.transformer import Transformer

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ cachetools==4.0.0
 Sphinx>=2.3.1
 sphinx-rtd-theme==0.4.3
 sphinx-click==2.3.1
-orderedset>=2.0.3
+ordered-set==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     "stringcase>=1.2.0",
     "validators>=0.13.0",
     "cachetools>-4.0.0",
-    "orderedset>=2.0.3"
+    "ordered-set>=4.0.2"
 ]
 
 EXTRAS = {}


### PR DESCRIPTION
Swapping OrderedSet for ordered-set because OrderedSet library is difficult to install in certain environments and the installation requires C headers that are not canonical 