### PR TITLE
Fixed incorrect named parameter in 'save' method

### DIFF
--- a/bin/translator_kgx.py
+++ b/bin/translator_kgx.py
@@ -613,7 +613,7 @@ def transform(config: dict, inputs: List[str], input_type: str, output: str, out
     if output_transformer is None:
         logging.error('Output does not have a recognized type: ' + str(get_file_types()))
     w = output_transformer(input_transformer.graph)
-    w.save(output, extension=output_type)
+    w.save(output, output_format=output_type)
 
 
 # @cli.command()


### PR DESCRIPTION
Transformer 'save' methods receive their target output format as the named argument 'output_format' not 'extension'. The code as written here would always default to 'csv', ignoring the 'output_type' communicated to it. Frustrating subtle bug!!!