### PR TITLE
Bug fixes and add support for Jsonlines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7
+MAINTAINER  Deepak Unni "deepak.unni3@gmail.com"
+
+# Clone repository
+RUN git clone https://github.com/NCATS-Tangerine/kgx && cd kgx && git checkout tags/0.1.0
+
+# Setup
+RUN cd kgx && python setup.py install
+
+# Make data directory
+RUN mkdir data
+
+WORKDIR /kgx
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -7,20 +7,23 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=NCATS-Tangerine_kgx&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=NCATS-Tangerine_kgx)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=NCATS-Tangerine_kgx&metric=coverage)](https://sonarcloud.io/dashboard?id=NCATS-Tangerine_kgx)
 
-KGX (Knowledge Graph Exchange) is a Python library and set of command line utilities for exchanging Knowledge Graphs (KGs) that conform to or are aligned to the [Biolink Model](https://biolink.github.io/biolink-model/).
+KGX (Knowledge Graph Exchange) is a Python library and set of command line utilities for exchanging
+Knowledge Graphs (KGs) that conform to or are aligned to the [Biolink Model](https://biolink.github.io/biolink-model/).
 
-The core datamodel is a [Property Graph](https://neo4j.com/developer/graph-database/) (PG), represented internally in Python using a [networkx MultiDiGraph model](https://networkx.github.io/documentation/stable/reference/classes/generated/networkx.MultiDiGraph.edges.html).
+The core datamodel is a [Property Graph](https://neo4j.com/developer/graph-database/) (PG), represented
+internally in Python using a [networkx MultiDiGraph model](https://networkx.github.io/documentation/stable/reference/classes/generated/networkx.MultiDiGraph.edges.html).
 
 KGX allows conversion to and from:
 
  * RDF serializations (read/write) and SPARQL endpoints (read)
- * Neo4j endpoints (read) or Neo4J dumps (write)
+ * Neo4j endpoints (read) or Neo4j dumps (write)
  * CSV/TSV and JSON (see [associated data formats](./data-preparation.md) and [example script to load CSV/TSV to Neo4j](./examples/scripts/load_csv_to_neo4j.py))
  * Reasoner Standard API format
  * OBOGraph JSON format
 
 
-KGX will also provide validation, to ensure the KGs are conformant to the Biolink Model: making sure nodes are categorized using Biolink classes, edges are labeled using valid Biolink relationship types, and valid properties are used.
+KGX will also provide validation, to ensure the KGs are conformant to the Biolink Model: making sure nodes are
+categorized using Biolink classes, edges are labeled using valid Biolink relationship types, and valid properties are used.
 
 
 ## Internal Representation
@@ -42,7 +45,18 @@ The structure of this graph is expected to conform to the Biolink Model standard
     * Other properties
 
 
-## Installation
+## Installation for Users
+
+KGX is available on [PyPI](https://pypi.org/project/kgx/) and you can install KGX via `python pip`.
+
+> **Note:** the installation of KGX requires Python 3.7+
+
+```bash
+pip install kgx
+```
+
+
+## Installation for Developers
 
 ### Python 3.7+ and Core Tool Dependencies
 
@@ -50,7 +64,8 @@ The structure of this graph is expected to conform to the Biolink Model standard
 
 You should first confirm what version of Python 
 you have running and upgrade to v3.7 as necessary, following best practices of your operating system. 
-It is also assumed that the common development tools are installed including git, pip, and all necessary development libraries for your operating system.
+It is also assumed that the common development tools are installed including git, pip, and all necessary
+development libraries for your operating system.
 
 
 ### Getting the Project Code
@@ -85,37 +100,21 @@ python3 -m venv venv
 source venv/bin/activate
 ```
 
-To exit the environment, type:
-
-```
-deactivate
-```
-
-To re-enter, source the `activate` command again.
-
-Alternately, you can also use **conda env** to manage packages and the development environment:
-
-```bash
-conda create -n translator-modules python=3.7
-conda activate translator-modules
-```
-
-Some IDE's (e.g. PyCharm) may also have provisions for directly creating a virtual environment. This should work just fine.
-
 
 ### Installing Python Dependencies 
 
-The Python dependencies of the application need to be installed into the local environment using a version of `pip` matched to your Python 3.7+ installation (assumed here to be called `pip3`). 
+The Python dependencies of the application need to be installed into the local environment using a version
+of `pip` matched to your Python 3.7+ installation (assumed here to be called `pip3`).
 
-Again, follow the specific directives of your operating system for the installation.
-
-For example, under Ubuntu Linux, to install the Python 3.7 matched version of pip, type the following:
-
-```bash
-sudo apt-get install python3-pip
-```
-
-which will install the `pip3` command.  
+> Again, follow the specific directives of your operating system for the installation.
+> 
+> For example, under Ubuntu Linux, to install the Python 3.7 matched version of pip, type the following:
+> 
+> ```bash
+> sudo apt-get install python3-pip
+> ```
+> 
+> which will install the `pip3` command.
 
 At this point, it is advisable to separately install the `wheel` package dependency before proceeding further 
 (Note: it is  assumed here that your `venv` is activated)
@@ -128,14 +127,18 @@ pip3 install wheel
 After installation of the `wheel` package, we install the remaining KGX Python package dependencies without error:
 
 ```bash
-pip3 install .
+pip3 install -r requirements.txt
 ```
 
-It is *sometimes* better to use the `python -m pip` version of pip rather than just `pip`
-to ensure that the proper version of pip - i.e. for the python3 in your virtual environment - is used 
-(i.e. once again, better check your pip version.  On some systems, it may run the operating system's version, 
-which may not be compatible with your `venv` installed Python 3.7)
+To install KGX,
 
 ```bash
-python -m pip install .
+python3 setup.py install
 ```
+
+To test installation was successful, run the following:
+```bash
+kgx --help
+```
+
+which invokes the KGX CLI tool.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -92,6 +92,16 @@ Transform a graph from one serialization to another.
                   tests/resources/graph_nodes.tsv tests/resources/graph_edges.tsv
 
 
+Alternatively, you can also perform transformation driven by a YAML.
+
+A sample of the merge configuration can be found `here <https://github.com/NCATS-Tangerine/kgx/blob/master/examples/sample-transform-config.yml>`_
+
+
+.. code-block:: bash
+
+    kgx transform --transform-config transform.yaml
+
+
 merge
 ^^^^^
 
@@ -101,5 +111,5 @@ A sample of the merge configuration can be found `here <https://github.com/NCATS
 
 .. code-block:: bash
 
-    kgx merge merge.yaml
+    kgx merge --merge-config merge.yaml
 

--- a/examples/sample-merge-config.yml
+++ b/examples/sample-merge-config.yml
@@ -1,68 +1,104 @@
 configuration:
-  output_directory: 'output_data'
+  output_directory: output_data
+  checkpoint: false
+  curie_map:
+    # define non-canonical CURIE to IRI mappings (for RDF)
+  node_properties:
+    # define predicates that are to be treated as direct node properties (for RDF)
+  predicate_mappings:
+    # map non-canonical predicates to a property name (for RDF)
+  property_types:
+    # define the type for non-canonical properties for RDF export
 merged_graph:
-  target:
+  name: Merged Graph
+  targets:
     sequence-ontology:
-      type: owl
-      filename: data/so.owl
+      input:
+        name: "Sequence Ontology"
+        format: owl
+        filename:
+          - data/so.owl
     hgnc-dataset:
-      type: ttl
-      filename: data/hgnc_test.ttl
+      curie_map:
+        # define non-canonical CURIE to IRI mappings (for RDF), specifically for this target
+      node_properties:
+        # define predicates that are to be treated as direct node properties (for RDF), specifically for this target
+      predicate_mappings:
+        # map non-canonical predicates to a property name (for RDF), specifically for this target
+      property_types:
+        # define the type for non-canonical properties for RDF export,  specifically for this target
+      input:
+        name: "HGNC"
+        format: nt
+        filename:
+          - data/hgnc.nt
     test-dataset:
-      type: tsv
-      compression: tar.gz
-      filename: data/test_dataset.tar.gz
-      filters:
-        node_filters:
-          category:
-            - biolink:Gene
-            - biolink:Disease
-        edge_filters:
-          edge_label:
-            - biolink:contributes_to
+      input:
+        format: tsv
+        compression: tar.gz
+        filename:
+          - data/test_dataset.tar.gz
+        filters:
+          node_filters:
+            category:
+              - biolink:Gene
+              - biolink:Disease
+          edge_filters:
+            edge_label:
+              - biolink:contributes_to
     neo-kg:
-      type: neo4j
-      uri: http://localhost:7474
-      username: neo4j
-      password: neo4j
-      page_size: 10000
-      filters:
-        node_filters:
-          category:
-            - biolink:Gene
-            - biolink:Disease
-            - biolink:PhenotypicFeature
-        edge_filters:
-          subject_category:
-            - biolink:Gene
-            - biolink:Disease
-          object_category:
-            - biolink:PhenotypicFeature
-          edge_label:
-            - biolink:interacts_with
-            - biolink:has_phenotype
+      input:
+        format: neo4j
+        uri: http://localhost:7474
+        username: neo4j
+        password: neo4j
+        page_size: 10000
+        filters:
+          node_filters:
+            category:
+              - biolink:Gene
+              - biolink:Disease
+              - biolink:PhenotypicFeature
+          edge_filters:
+            subject_category:
+              - biolink:Gene
+              - biolink:Disease
+            object_category:
+              - biolink:PhenotypicFeature
+            edge_label:
+              - biolink:interacts_with
+              - biolink:has_phenotype
     sparql-kg:
-      type: sparql
-      uri: http://localhost/sparql
-    #      filters:
-    #         edge_filters:
-    #            subject_category:
-    #               - biolink:Gene
-    #               - biolink:PhenotypicFeature
-    #            object_category:
-    #               - biolink:Disease
-    #            edge_label:
-    #               - biolink:is_marker_for
-    #               - biolink:has_phenotype
+      input:
+        format: sparql
+        uri: http://localhost/sparql
+        filters:
+          edge_filters:
+            subject_category:
+              - biolink:Gene
+              - biolink:PhenotypicFeature
+            object_category:
+              - biolink:Disease
+            edge_label:
+              - biolink:is_marker_for
+              - biolink:has_phenotype
     local-kg:
-      type: json
-      filename: local-kg-dump.json
+      input:
+        format: json
+        filename:
+          - local-kg-dump.json
   operations:
-    - name: kgx.operations.clique_merge.clique_merge
+    - name: kgx.operations.summarize_graph.generate_graph_stats
       args:
-        leader_annotation: 'cliqueLeader'
-        prefix_prioritization_map:
-          'biolink:NamedThing': ['HGNC', 'NCBIGene', 'ENSEMBL']
+        graph_name: Merged Graph
+        filename: merged-kg_stats.yaml
+        node_facet_properties:
+          - provided_by
+        edge_facet_properties:
+          - provided_by
   destination:
-    type: tsv
-    filename: merged-kg
+    merged-kg-tsv:
+      format: tsv
+      compression: tar.gz
+      filename:
+        - merged-kg

--- a/examples/sample-transform-config.yml
+++ b/examples/sample-transform-config.yml
@@ -1,0 +1,81 @@
+configuration:
+  output_directory: output_data
+  checkpoint: false
+  curie_map:
+    # define non-canonical CURIE to IRI mappings (for RDF)
+  node_properties:
+    # define predicates that are to be treated as direct node properties (for RDF)
+  predicate_mappings:
+    # map non-canonical predicates to a property name (for RDF)
+  property_types:
+    # define the type for non-canonical properties for RDF export
+transform:
+  targets:
+    hgnc-dataset:
+      curie_map:
+        # define non-canonical CURIE to IRI mappings (for RDF), specifically for this target
+      node_properties:
+        # define predicates that are to be treated as direct node properties (for RDF), specifically for this target
+      predicate_mappings:
+        # map non-canonical predicates to a property name (for RDF), specifically for this target
+      property_types:
+        # define the type for non-canonical properties for RDF export,  specifically for this target
+      input:
+        name: "HGNC"
+        format: nt
+        filename:
+          - data/hgnc.nt
+      output:
+        format: tsv
+        compression: tar.gz
+        filename:
+          - hgnc_output
+    gene-ontology:
+      name: "Gene Ontology"
+      input:
+        format: obojson
+        compression: None
+        filename:
+          - data/go.json
+      operations:
+        - name: kgx.operations.summarize_graph.generate_graph_stats
+          args:
+            graph_name: GO graph
+            filename: go_graph_stats.yaml
+            node_facet_properties:
+              - provided_by
+            edge_facet_properties:
+              - provided_by
+      output:
+        format: tsv
+        compression: None
+        filename:
+          - monarch-ontologies-output
+    test-dataset:
+      input:
+        format: tsv
+        compression: tar.gz
+        filename:
+          - data/test_dataset.tar.gz
+        filters:
+          node_filters:
+            category:
+              - biolink:Gene
+              - biolink:Disease
+          edge_filters:
+            edge_label:
+              - biolink:contributes_to
+      operations:
+        - name: kgx.operations.summarize_graph.generate_graph_stats
+          args:
+            graph_name: Test Dataset
+            filename: test_dataset_stats.yaml
+            node_facet_properties:
+              - provided_by
+            edge_facet_properties:
+              - provided_by
+      output:
+        format: tsv
+        compression: None
+        filename:
+          - test-dataset-output

--- a/kgx/__init__.py
+++ b/kgx/__init__.py
@@ -3,6 +3,7 @@ from kgx.transformers.rdf_transformer import RdfTransformer, ObanRdfTransformer,
 from kgx.transformers.nt_transformer import NtTransformer
 from kgx.transformers.sparql_transformer import SparqlTransformer, RedSparqlTransformer
 from kgx.transformers.json_transformer import JsonTransformer, ObographJsonTransformer
+from kgx.transformers.jsonl_transformer import JsonlTransformer
 from kgx.transformers.rsa_transformer import RsaTransformer
 from kgx.transformers.neo_transformer import NeoTransformer
 from kgx.transformers.transformer import Transformer

--- a/kgx/cli/__init__.py
+++ b/kgx/cli/__init__.py
@@ -151,15 +151,18 @@ def neo4j_upload_wrapper(inputs: List[str], input_format: str, input_compression
 
 
 @cli.command('transform')
-@click.argument('inputs',  required=True, type=click.Path(exists=True), nargs=-1)
-@click.option('--input-format', required=True, help=f'The input format. Can be one of {get_file_types()}')
+@click.argument('inputs',  required=False, type=click.Path(exists=True), nargs=-1)
+@click.option('--input-format', required=False, help=f'The input format. Can be one of {get_file_types()}')
 @click.option('--input-compression', required=False, help='The input compression type')
-@click.option('--output', required=True, type=click.Path(exists=False), help='Output')
-@click.option('--output-format', required=True, help=f'The output format. Can be one of {get_file_types()}')
+@click.option('--output', required=False, type=click.Path(exists=False), help='Output')
+@click.option('--output-format', required=False, help=f'The output format. Can be one of {get_file_types()}')
 @click.option('--output-compression', required=False, help='The output compression type')
 @click.option('--node-filters', required=False, type=click.Tuple([str, str]), multiple=True, help=f'Filters for filtering nodes from the input graph')
 @click.option('--edge-filters', required=False, type=click.Tuple([str, str]), multiple=True, help=f'Filters for filtering edges from the input graph')
-def transform_wrapper(inputs: List[str], input_format: str, input_compression: str, output: str, output_format: str, output_compression: str, node_filters: Tuple, edge_filters: Tuple):
+@click.option('--transform-config', required=False, type=str, help=f'Transform config YAML')
+@click.option('--targets', required=False, type=str, multiple=True, help='Target(s) from the YAML to process')
+@click.option('--processes', required=False, type=int, default=1, help='Number of processes to use')
+def transform_wrapper(inputs: List[str], input_format: str, input_compression: str, output: str, output_format: str, output_compression: str, node_filters: Tuple, edge_filters: Tuple, transform_config: str, targets: List, processes: int):
     """
     Transform a Knowledge Graph from one serialization form to another.
     \f
@@ -182,13 +185,19 @@ def transform_wrapper(inputs: List[str], input_format: str, input_compression: s
         Node filters
     edge_filters: Tuple[str, str]
         Edge filters
+    merge_config: str
+        Merge config YAML
+    targets: List
+        A list of targets to load from the YAML
+    processes: int
+        Number of processes to use
 
     """
-    transform(inputs, input_format, input_compression, output, output_format, output_compression, node_filters, edge_filters)
+    transform(inputs, input_format, input_compression, output, output_format, output_compression, node_filters, edge_filters, transform_config, targets, processes)
 
 
 @cli.command(name='merge')
-@click.argument('merge-config', required=True, type=click.Path(exists=True))
+@click.option('--merge-config', required=True, type=str)
 @click.option('--targets', required=False, type=str, multiple=True, help='Target(s) from the YAML to process')
 @click.option('--processes', required=False, type=int, default=1, help='Number of processes to use')
 def merge_wrapper(merge_config: str, targets: List, processes: int):

--- a/kgx/cli/cli_utils.py
+++ b/kgx/cli/cli_utils.py
@@ -21,6 +21,7 @@ _transformers = {
     'nt': kgx.NtTransformer,
     'ttl': kgx.RdfTransformer,
     'json': kgx.JsonTransformer,
+    'jsonl': kgx.JsonlTransformer,
     'obojson': kgx.ObographJsonTransformer,
     # 'rq': kgx.SparqlTransformer,
     'owl': kgx.RdfOwlTransformer,
@@ -319,7 +320,7 @@ def transform(inputs: List[str], input_format: str, input_compression: str, outp
                 'filename': output
             }
         }
-        transform_target(None, target, output_directory)
+        transform_target(None, target, None)
 
 
 def merge(merge_config: str, targets: Optional[List] = None, processes: int = 1) -> networkx.MultiDiGraph:
@@ -559,11 +560,14 @@ def parse_target_input(key: str, target: Dict, output_directory: str, curie_map:
     edge_filters = filters['edge_filters'] if 'edge_filters' in filters else {}
     operations = target['input']['operations'] if 'operations' in target['input'] and target['filters'] is not None else {}
     target_curie_map = target['curie_map'] if 'curie_map' in target and target['curie_map'] is not None else {}
-    target_curie_map.update(curie_map)
+    if curie_map:
+        target_curie_map.update(curie_map)
     target_predicate_mappings = target['predicate_mappings'] if 'predicate_mappings' in target and target['predicate_mappings'] is not None else {}
-    target_predicate_mappings.update(predicate_mappings)
+    if predicate_mappings:
+        target_predicate_mappings.update(predicate_mappings)
     target_node_properties = target['node_properties'] if 'node_properties' in target and target['node_properties'] is not None else []
-    target_node_properties.extend(node_properties)
+    if node_properties:
+        target_node_properties.extend(node_properties)
 
     if input_format in {'nt', 'ttl'}:
         # Parse RDF file types

--- a/kgx/cli/cli_utils.py
+++ b/kgx/cli/cli_utils.py
@@ -17,6 +17,7 @@ _transformers = {
     'tar': kgx.PandasTransformer,
     'csv': kgx.PandasTransformer,
     'tsv': kgx.PandasTransformer,
+    'tsv:neo4j': kgx.PandasTransformer,
     'nt': kgx.NtTransformer,
     'ttl': kgx.RdfTransformer,
     'json': kgx.JsonTransformer,

--- a/kgx/cli/cli_utils.py
+++ b/kgx/cli/cli_utils.py
@@ -419,6 +419,7 @@ def merge(merge_config: str, targets: Optional[List] = None, processes: int = 1)
                     filename = filename[0]
                 destination_filename = f"{output_directory}/{filename}"
                 if destination['format'] == 'nt' and isinstance(destination_transformer, RdfTransformer):
+                    destination_transformer.set_predicate_mapping(predicate_mappings)
                     destination_transformer.set_property_types(property_types)
                 compression = destination['compression'] if 'compression' in destination else None
                 destination_transformer.save(

--- a/kgx/transformers/json_transformer.py
+++ b/kgx/transformers/json_transformer.py
@@ -376,7 +376,7 @@ class ObographJsonTransformer(JsonTransformer):
             elif prefix == 'PR':
                 category = "biolink:Protein"
             elif prefix == 'NCBITaxon':
-                category = "organism taxon"
+                category = "biolink:OrganismalEntity"
             else:
                 log.debug(f"{curie} Could not find a category mapping for '{category}'; Defaulting to 'biolink:OntologyClass'")
         return category

--- a/kgx/transformers/jsonl_transformer.py
+++ b/kgx/transformers/jsonl_transformer.py
@@ -1,0 +1,110 @@
+import gzip
+import re
+from typing import Optional
+
+import jsonlines as jsonlines
+import networkx
+
+from kgx import JsonTransformer
+from kgx.config import get_logger
+
+log = get_logger()
+
+
+class JsonlTransformer(JsonTransformer):
+    """
+    Transformer that parsers JSONLines (*.jsonl), and loads nodes and edges into a networkx.MultiDiGraph
+
+    Parameters
+    ----------
+    source_graph: Optional[networkx.MultiDiGraph]
+        The source graph
+
+    """
+    def __init__(self, source_graph: Optional[networkx.MultiDiGraph] = None):
+        super().__init__(source_graph)
+
+    def parse(self, filename: str, input_format: str = 'jsonl', compression: Optional[str] = None, provided_by: Optional[str] = None, **kwargs) -> None:
+        """
+        Parse jsonl files.
+
+        .. note::
+            This is a specialized version of JsonTransformer that supports reading and writing jsonlines.
+            Due to the nature of the jsonl format, this method expects nodes and edges to be in separate files.
+
+        Parameters
+        ----------
+        filename: str
+            JSON file to read from
+        input_format: str
+            The input file format (``jsonl``, by default)
+        compression: Optional[str]
+            The compression type. For example, ``gz``
+        provided_by: Optional[str]
+            Define the source providing the input file
+        kwargs: dict
+            Any additional arguments
+        """
+        log.info("Parsing {}".format(filename))
+        if provided_by:
+            self.graph_metadata['provided_by'] = [provided_by]
+        if re.search(f'nodes.{input_format}', filename):
+            m = self.load_node
+        elif re.search(f'edges.{input_format}', filename):
+            m = self.load_edge
+        else:
+            raise TypeError(f"Unrecognized file: {filename}")
+
+        if compression == 'gz':
+            with gzip.open(filename, 'rb') as FH:
+                reader = jsonlines.Reader(FH)
+                for obj in reader:
+                    m(obj)
+        else:
+            with jsonlines.open(filename) as FH:
+                for obj in FH:
+                    m(obj)
+
+    def save(self, filename: str, output_format: str = 'jsonl', compression: Optional[str] = None, **kwargs) -> str:
+        """
+        Write networkx.MultiDiGraph to jsonl.
+        This method writes nodes to ``*nodes.jsonl`` and edges to ``edges.jsonl``
+
+        Parameters
+        ----------
+        filename: str
+            Filename to write to
+        output_format: str
+            The output file format (``jsonl``, by default)
+        compression: Optional[str]
+            The compression type. For example, ``gz``
+        kwargs: dict
+            Any additional arguments
+
+        Returns
+        -------
+        str
+            The filename
+
+        """
+        nodes_filename = f"{filename}_nodes.jsonl"
+        edges_filename = f"{filename}_edges.jsonl"
+        if compression == 'gz':
+            nodes_filename += f".{compression}"
+            edges_filename += f".{compression}"
+            with gzip.open(nodes_filename, 'wb') as WH:
+                writer = jsonlines.Writer(WH)
+                for n, data in self.graph.nodes(data=True):
+                    writer.write(data)
+            with gzip.open(edges_filename, 'wb') as WH:
+                writer = jsonlines.Writer(WH)
+                for u, v, k, data in self.graph.edges(data=True, keys=True):
+                    writer.write(data)
+        else:
+            with jsonlines.open(nodes_filename, 'w') as WH:
+                for n, data in self.graph.nodes(data=True):
+                    WH.write(data)
+            with jsonlines.open(edges_filename, 'w') as WH:
+                for u, v, k, data in self.graph.edges(data=True, keys=True):
+                    WH.write(data)
+        return filename

--- a/kgx/transformers/neo_transformer.py
+++ b/kgx/transformers/neo_transformer.py
@@ -5,7 +5,7 @@ from typing import Tuple, List, Dict, Union, Any, Iterator, Optional
 
 from kgx.config import get_logger
 from kgx.transformers.transformer import Transformer
-from kgx.utils.kgx_utils import generate_edge_key, current_time_in_millis
+from kgx.utils.kgx_utils import generate_edge_key, current_time_in_millis, generate_uuid
 from neo4jrestclient.client import GraphDatabase as http_gdb, Node, Relationship, GraphDatabase
 from neo4jrestclient.query import CypherException
 
@@ -189,7 +189,8 @@ class NeoTransformer(Transformer):
 
         if 'provided_by' in self.graph_metadata and 'provided_by' not in edge.keys():
             edge['provided_by'] = self.graph_metadata['provided_by']
-
+        if 'id' not in edge.keys():
+            edge['id'] = generate_uuid()
         key = generate_edge_key(subject_node['id'], edge['edge_label'], object_node['id'])
         self.graph.add_edge(subject_node['id'], object_node['id'], key, **edge)
 

--- a/kgx/transformers/nt_transformer.py
+++ b/kgx/transformers/nt_transformer.py
@@ -9,7 +9,7 @@ import networkx as nx
 
 from kgx import RdfTransformer
 from kgx.config import get_logger
-from kgx.utils.kgx_utils import current_time_in_millis, apply_filters
+from kgx.utils.kgx_utils import current_time_in_millis, apply_filters, generate_edge_identifiers
 
 log = get_logger()
 
@@ -63,6 +63,7 @@ class NtTransformer(RdfTransformer):
         self.dereify(self.reified_nodes)
         log.info(f"Done parsing {filename}")
         apply_filters(self.graph, self.node_filters, self.edge_filters)
+        generate_edge_identifiers(self.graph)
 
     def save(self, filename: str, output_format: str = 'nt', compression: str = None, reify_all_edges = False, **kwargs) -> None:
         """

--- a/kgx/transformers/pandas_transformer.py
+++ b/kgx/transformers/pandas_transformer.py
@@ -8,7 +8,7 @@ import tarfile
 from ordered_set import OrderedSet
 
 from kgx.config import get_logger
-from kgx.utils.kgx_utils import generate_edge_key
+from kgx.utils.kgx_utils import generate_edge_key, generate_uuid
 from kgx.transformers.transformer import Transformer
 
 from typing import List, Dict, Optional, Any, Set
@@ -317,6 +317,8 @@ class PandasTransformer(Transformer):
             edge = Transformer.validate_edge(edge)
             kwargs = PandasTransformer._build_kwargs(edge.copy())
             if 'subject' in kwargs and 'object' in kwargs:
+                if 'id' not in kwargs:
+                    kwargs['id'] = generate_uuid()
                 s = kwargs['subject']
                 o = kwargs['object']
                 if 'provided_by' in self.graph_metadata and 'provided_by' not in kwargs.keys():

--- a/kgx/transformers/rdf_graph_mixin.py
+++ b/kgx/transformers/rdf_graph_mixin.py
@@ -7,7 +7,7 @@ from rdflib import URIRef, Namespace
 from kgx.config import get_logger
 from kgx.curie_lookup_service import CurieLookupService
 from kgx.utils.graph_utils import curie_lookup
-from kgx.utils.rdf_utils import property_mapping, is_property_multivalued, generate_uuid, reverse_property_mapping
+from kgx.utils.rdf_utils import property_mapping, is_property_multivalued, reverse_property_mapping
 from kgx.utils.kgx_utils import generate_edge_key, get_toolkit, sentencecase_to_camelcase, sentencecase_to_snakecase
 from kgx.prefix_manager import PrefixManager
 

--- a/kgx/transformers/rdf_graph_mixin.py
+++ b/kgx/transformers/rdf_graph_mixin.py
@@ -8,7 +8,8 @@ from kgx.config import get_logger
 from kgx.curie_lookup_service import CurieLookupService
 from kgx.utils.graph_utils import curie_lookup
 from kgx.utils.rdf_utils import property_mapping, is_property_multivalued, reverse_property_mapping
-from kgx.utils.kgx_utils import generate_edge_key, get_toolkit, sentencecase_to_camelcase, sentencecase_to_snakecase
+from kgx.utils.kgx_utils import generate_edge_key, get_toolkit, sentencecase_to_camelcase, sentencecase_to_snakecase, \
+    get_biolink_ancestors
 from kgx.prefix_manager import PrefixManager
 
 log = get_logger()
@@ -517,6 +518,8 @@ class RdfGraphMixin(object):
                     element_uri = self.prefix_manager.contract(element.class_uri)
                 else:
                     element_uri = f"biolink:{sentencecase_to_camelcase(element.name)}"
+                if 'biolink:Attribute' in get_biolink_ancestors(element.name):
+                    element_uri = f"biolink:{sentencecase_to_snakecase(element.name)}"
                 if not predicate:
                     predicate = element_uri
             else:

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -10,10 +10,10 @@ from kgx.config import get_logger
 from kgx.prefix_manager import PrefixManager
 from kgx.transformers.transformer import Transformer
 from kgx.transformers.rdf_graph_mixin import RdfGraphMixin
-from kgx.utils.rdf_utils import property_mapping, reverse_property_mapping, generate_uuid
+from kgx.utils.rdf_utils import property_mapping, reverse_property_mapping
 from kgx.utils.kgx_utils import get_toolkit, get_biolink_node_properties, get_biolink_edge_properties, \
-    current_time_in_millis, get_biolink_association_types, get_biolink_property_types, apply_filters
-
+    current_time_in_millis, get_biolink_association_types, get_biolink_property_types, apply_filters, \
+    generate_edge_identifiers, generate_uuid
 
 log = get_logger()
 
@@ -135,7 +135,7 @@ class RdfTransformer(RdfGraphMixin, Transformer):
         self.load_networkx_graph(rdfgraph)
         log.info(f"Done parsing {filename}")
         apply_filters(self.graph, self.node_filters, self.edge_filters)
-        self.report()
+        generate_edge_identifiers(self.graph)
 
     def load_networkx_graph(self, rdfgraph: rdflib.Graph, predicates: Optional[Set[URIRef]] = None, **kwargs: Dict) -> None:
         """
@@ -707,3 +707,5 @@ class RdfOwlTransformer(RdfTransformer):
             if p in seen:
                 continue
             self.triple(s, p, o)
+
+        generate_edge_identifiers(self.graph)

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -337,6 +337,10 @@ class RdfTransformer(RdfGraphMixin, Transformer):
                         #prop_uri = self.prefix_manager.contract(prop_uri)
                     else:
                         prop_uri = k
+                        if self.prefix_manager.is_curie(k):
+                            prop_uri = k
+                        else:
+                            prop_uri = f":{k}"
                 else:
                     prop_uri = canonical_uri if canonical_uri else element_uri
                 prop_type = self._get_property_type(prop_uri)

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -337,13 +337,10 @@ class RdfTransformer(RdfGraphMixin, Transformer):
                         #prop_uri = self.prefix_manager.contract(prop_uri)
                     else:
                         prop_uri = k
-                        if self.prefix_manager.is_curie(k):
-                            prop_uri = k
-                        else:
-                            prop_uri = f":{k}"
                 else:
                     prop_uri = canonical_uri if canonical_uri else element_uri
                 prop_type = self._get_property_type(prop_uri)
+                log.debug(f"prop {k} has prop_uri {prop_uri} and prop_type {prop_type}")
                 prop_uri = self.uriref(prop_uri)
                 if isinstance(v, (list, set, tuple)):
                     for x in v:
@@ -392,7 +389,8 @@ class RdfTransformer(RdfGraphMixin, Transformer):
                             #prop_uri = self.prefix_manager.contract(prop_uri)
                         else:
                             prop_uri = predicate
-                    prop_type = self._get_property_type(prop_uri)
+                    prop_type = self._get_property_type(prop)
+                    log.debug(f"prop {prop} has prop_uri {prop_uri} and prop_type {prop_type}")
                     prop_uri = self.uriref(prop_uri)
                     if isinstance(value, list):
                         for x in value:
@@ -421,7 +419,8 @@ class RdfTransformer(RdfGraphMixin, Transformer):
                                 #prop_uri = self.prefix_manager.contract(prop_uri)
                             else:
                                 prop_uri = predicate
-                        prop_type = self._get_property_type(prop_uri)
+                        prop_type = self._get_property_type(prop)
+                        log.debug(f"prop {prop} has prop_uri {prop_uri} and prop_type {prop_type}")
                         prop_uri = self.uriref(prop_uri)
                         if isinstance(value, list):
                             for x in value:
@@ -497,6 +496,8 @@ class RdfTransformer(RdfGraphMixin, Transformer):
         else:
             if p in self.property_types:
                 t = self.property_types[p]
+            elif f':{p}' in self.property_types:
+                t = self.property_types[f':{p}']
             elif f'biolink:{p}' in self.property_types:
                 t = self.property_types[f'biolink:{p}']
             else:
@@ -537,18 +538,24 @@ class RdfTransformer(RdfGraphMixin, Transformer):
             uri = reverse_property_mapping[identifier]
         else:
             # identifier is an entity
-            if identifier.startswith(':'):
+            fixed_identifier = identifier
+            if fixed_identifier.startswith(':'):
                 # TODO: this should be handled upstream by prefixcommons-py
-                uri = self.DEFAULT.term(identifier.replace(':', '', 1))
+                fixed_identifier = fixed_identifier.replace(':', '', 1)
+            if ' ' in identifier:
+                fixed_identifier = fixed_identifier.replace(' ', '_')
+
+            if self.prefix_manager.is_curie(fixed_identifier):
+                uri = self.prefix_manager.expand(fixed_identifier)
+                if fixed_identifier == uri:
+                    uri = self.DEFAULT.term(fixed_identifier)
+            elif self.prefix_manager.is_iri(fixed_identifier):
+                uri = fixed_identifier
             else:
-                uri = self.prefix_manager.expand(identifier)
+                uri = self.DEFAULT.term(fixed_identifier)
             # if identifier == uri:
             #     if PrefixManager.is_curie(identifier):
             #         identifier = identifier.replace(':', '_')
-            #     if ' ' in identifier:
-            #         identifier = identifier.replace(' ', '_')
-            #     uri = self.DEFAULT.term(identifier)
-
         return URIRef(uri)
 
 

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -234,8 +234,11 @@ class RdfTransformer(RdfGraphMixin, Transformer):
                 node['relation'] = node['edge_label']
             if 'category' in node:
                 del node['category']
-            self.add_edge(node['subject'], node['object'], node['edge_label'], node)
-            self.graph.remove_node(n_curie)
+            if 'subject' in node and 'object' in node:
+                self.add_edge(node['subject'], node['object'], node['edge_label'], node)
+                self.graph.remove_node(n_curie)
+            else:
+                log.warning(f"Cannot dereify node {n} {node}")
 
     def reify(self, u: str, v: str, k: str, data: Dict) -> Dict:
         """

--- a/kgx/utils/kgx_utils.py
+++ b/kgx/utils/kgx_utils.py
@@ -1,5 +1,6 @@
 import re
 import time
+import uuid
 from typing import List, Dict, Set, Optional, Any, Union
 
 import networkx
@@ -629,3 +630,31 @@ def apply_edge_filters(graph: networkx.MultiDiGraph, edge_filters: Dict[str, Uni
         # removing edge that fails edge filters
         log.debug(f"Removing edge {edge}")
         graph.remove_edge(edge[0], edge[1], edge[2])
+
+
+def generate_uuid():
+    """
+    Generates a UUID.
+
+    Returns
+    -------
+    str
+        A UUID
+
+    """
+    return f"urn:uuid:{uuid.uuid4()}"
+
+
+def generate_edge_identifiers(graph: networkx.MultiDiGraph):
+    """
+    Generate unique identifiers for edges in a graph that do not
+    have an ``id`` field.
+
+    Parameters
+    ----------
+    graph: networkx.MultiDiGraph
+
+    """
+    for u, v, data in graph.edges(data=True):
+        if 'id' not in data:
+            data['id'] = generate_uuid()

--- a/kgx/utils/kgx_utils.py
+++ b/kgx/utils/kgx_utils.py
@@ -321,10 +321,27 @@ def get_cache(maxsize=10000):
 
 
 def current_time_in_millis():
+    """
+    Get current time in milliseconds.
+
+    Returns
+    -------
+    int
+        Time in milliseconds
+
+    """
     return int(round(time.time() * 1000))
 
 
-def get_prefix_prioritization_map():
+def get_prefix_prioritization_map() -> Dict[str, List]:
+    """
+    Get prefix prioritization map as defined in Biolink Model.
+
+    Returns
+    -------
+    Dict[str, List]
+
+    """
     toolkit = get_toolkit()
     prefix_prioritization_map = {}
     # TODO: Lookup via Biolink CURIE should be supported in bmt
@@ -339,7 +356,21 @@ def get_prefix_prioritization_map():
     return prefix_prioritization_map
 
 
-def get_biolink_element(name):
+def get_biolink_element(name) -> Optional[Element]:
+    """
+    Get Biolink element for a given name, where name can be a class, slot, or relation.
+
+    Parameters
+    ----------
+    name: str
+        The name
+
+    Returns
+    -------
+    Optional[biolinkml.meta.Element]
+        An instance of biolinkml.meta.Element
+
+    """
     toolkit = get_toolkit()
     if re.match("biolink:.+", name):
         name = name.split(':', 1)[1]
@@ -349,7 +380,20 @@ def get_biolink_element(name):
     return element
 
 
-def get_biolink_ancestors(name):
+def get_biolink_ancestors(name: str):
+    """
+    Get ancestors for a given Biolink class.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    List
+        A list of ancestors
+
+    """
     toolkit = get_toolkit()
     if re.match("biolink:.+", name):
         name = name.split(':', 1)[1]
@@ -360,7 +404,16 @@ def get_biolink_ancestors(name):
     return formatted_ancestors
 
 
-def get_biolink_node_properties():
+def get_biolink_node_properties() -> Set:
+    """
+    Get all Biolink node properties.
+
+    Returns
+    -------
+    Set
+        A set containing all Biolink node properties
+
+    """
     toolkit = get_toolkit()
     properties = toolkit.children('node property')
     # TODO: fix bug in bmt when getting descendants
@@ -373,7 +426,16 @@ def get_biolink_node_properties():
     return set([format_biolink_slots(x) for x in node_properties])
 
 
-def get_biolink_edge_properties():
+def get_biolink_edge_properties() -> Set:
+    """
+    Get all Biolink edge properties.
+
+    Returns
+    -------
+    Set
+        A set containing all Biolink edge properties
+
+    """
     toolkit = get_toolkit()
     properties = toolkit.children('association slot')
     edge_properties = set()
@@ -384,13 +446,32 @@ def get_biolink_edge_properties():
     return set([format_biolink_slots(x) for x in edge_properties])
 
 
-def get_biolink_relations():
+def get_biolink_relations() -> Set:
+    """
+    Get all Biolink relations.
+
+    Returns
+    -------
+    Set
+        A set containing all Biolink relations
+
+    """
     toolkit = get_toolkit()
-    relations = toolkit.descendents('related to')
+    relations = set(toolkit.descendents('related to'))
     return relations
 
 
-def get_biolink_property_types():
+def get_biolink_property_types() -> Set:
+    """
+    Get all Biolink property types.
+    This includes both node and edges properties.
+
+    Returns
+    -------
+    Set
+        A set containing all Biolink property types
+
+    """
     toolkit = get_toolkit()
     types = {}
     node_properties = set()
@@ -417,8 +498,25 @@ def get_biolink_property_types():
     # TODO: this should be moved to biolink model
     types['biolink:predicate'] = 'uriorcurie'
     types['biolink:edge_label'] = 'uriorcurie'
-
     return types
+
+
+def get_biolink_association_types() -> Set:
+    """
+    Get all Biolink association types.
+
+    Returns
+    -------
+    Set
+        A set containing all Biolink association types
+
+    """
+    toolkit = get_toolkit()
+    associations = toolkit.descendents('association')
+    associations.append('association')
+    formatted_associations = set([format_biolink_category(x) for x in associations])
+    return formatted_associations
+
 
 def get_type_for_property(p: str) -> str:
     """
@@ -456,15 +554,30 @@ def get_type_for_property(p: str) -> str:
     return t
 
 
-def get_biolink_association_types():
-    toolkit = get_toolkit()
-    associations = toolkit.descendents('association')
-    associations.append('association')
-    formatted_associations = set([format_biolink_category(x) for x in associations])
-    return formatted_associations
+def prepare_data_dict(d1: Dict, d2: Dict, preserve: bool = True) -> Dict:
+    """
+    Given two dict objects, make a new dict object that is the intersection of the two.
 
+    If a key is known to be multivalued then it's value is converted to a list.
+    If a key is already multivalued then it is updated with new values.
+    If a key is single valued, and a new unique value is found then the existing value is
+    converted to a list and the new value is appended to this list.
 
-def prepare_data_dict(d1, d2, preserve = True):
+    Parameters
+    ----------
+    d1: Dict
+        Dict object
+    d2: Dict
+        Dict object
+    preserve: bool
+        Whether or not to preserve values for conflicting keys
+
+    Returns
+    -------
+    Dict
+        The intersection of d1 and d2
+
+    """
     new_data = {}
     for key, value in d2.items():
         if isinstance(value, (list, set, tuple)):

--- a/kgx/utils/rdf_utils.py
+++ b/kgx/utils/rdf_utils.py
@@ -77,19 +77,6 @@ top_level_terms = {
 }
 
 
-def generate_uuid():
-    """
-    Generates a UUID.
-
-    Returns
-    -------
-    str
-        A UUID
-
-    """
-    return f"urn:uuid:{uuid.uuid4()}"
-
-
 def infer_category(iri: URIRef, rdfgraph:rdflib.Graph) -> Optional[List]:
     """
     Infer category for a given iri by traversing rdfgraph.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ sphinx-click>=2.3.1
 ordered-set>=4.0.2
 docker>=4.2.2
 pathlib>=1.0.0
+jsonlines>=1.2.0

--- a/tests/resources/valid_edges.jsonl
+++ b/tests/resources/valid_edges.jsonl
@@ -1,0 +1,5 @@
+{"id": "a8575c4e-61a6-428a-bf09-fcb3e8d1644d", "subject": "HGNC:11603", "object": "MONDO:0005002", "edge_label": "biolink:related_to", "relation": "RO:0003304"}
+{"id": "2d38345a-e9bf-4943-accb-dccba351dd04", "subject": "HGNC:11603", "object": "MONDO:0013238", "edge_label": "biolink:related_to", "relation": "RO:0003304"}
+{"id": "d7edcb4b-af58-468a-8f86-ed737859693a", "subject": "HGNC:11603", "object": "MONDO:0013329", "edge_label": "biolink:related_to", "relation": "RO:0003304"}
+{"id": "044a7916-fba9-4b4f-ae48-f0815b0b222d", "subject": "HGNC:11603", "object": "MONDO:0017148", "edge_label": "biolink:related_to", "relation": "RO:0004013"}
+{"id": "1a7f02a7-24ab-4480-809d-f61e80876b70", "subject": "HGNC:11603", "object": "MONDO:0007841", "edge_label": "biolink:related_to", "relation": "RO:0004013"}

--- a/tests/resources/valid_nodes.jsonl
+++ b/tests/resources/valid_nodes.jsonl
@@ -1,0 +1,6 @@
+{"id": "HGNC:11603", "name": "TBX4", "category": ["biolink:Gene"]}
+{"id": "MONDO:0005002", "name": "chronic obstructive pulmonary disease", "category": ["biolink:Disease"]}
+{"id": "MONDO:0013238", "name": "chromosome 17q23.1-q23.2 deletion syndrome", "category": ["biolink:Disease"]}
+{"id": "MONDO:0013329", "name": "familial clubfoot due to 17q23.1q23.2 microduplication", "category": ["biolink:Disease"]}
+{"id": "MONDO:0017148", "name": "heritable pulmonary arterial hypertension", "category": ["biolink:Disease"]}
+{"id": "MONDO:0007841", "name": "coxopodopatellar syndrome", "category": ["biolink:Disease"]}

--- a/tests/unit/test_jsonl_transformer.py
+++ b/tests/unit/test_jsonl_transformer.py
@@ -1,0 +1,57 @@
+import os
+
+from kgx import JsonlTransformer
+
+cwd = os.path.abspath(os.path.dirname(__file__))
+resource_dir = os.path.join(cwd, '../resources')
+target_dir = os.path.join(cwd, '../target')
+
+
+def test_jsonl_load():
+    jlt = JsonlTransformer()
+    jlt.parse(os.path.join(resource_dir, 'valid_nodes.jsonl'), input_format='jsonl')
+    jlt.parse(os.path.join(resource_dir, 'valid_edges.jsonl'), input_format='jsonl')
+
+    assert jlt.graph.number_of_nodes() == 6
+    assert jlt.graph.number_of_edges() == 5
+
+    n1 = jlt.graph.nodes['HGNC:11603']
+    assert n1['name'] == 'TBX4'
+    assert 'biolink:Gene' in n1['category']
+
+    e1 = list(jlt.graph.get_edge_data('HGNC:11603', 'MONDO:0005002').values())[0]
+    assert e1['subject'] == 'HGNC:11603'
+    assert e1['object'] == 'MONDO:0005002'
+    assert e1['edge_label'] == 'biolink:related_to'
+    assert e1['relation'] == 'RO:0003304'
+
+
+def test_jsonl_save1():
+    jlt = JsonlTransformer()
+    jlt.parse(os.path.join(resource_dir, 'valid_nodes.jsonl'), input_format='jsonl')
+    jlt.parse(os.path.join(resource_dir, 'valid_edges.jsonl'), input_format='jsonl')
+
+    assert jlt.graph.number_of_nodes() == 6
+    assert jlt.graph.number_of_edges() == 5
+
+    jlt.save(os.path.join(target_dir, 'valid-export'))
+    assert os.path.exists(os.path.join(target_dir, 'valid-export_nodes.jsonl'))
+    assert os.path.exists(os.path.join(target_dir, 'valid-export_edges.jsonl'))
+
+    jlt.save(os.path.join(target_dir, 'valid-export'), compression='gz')
+    assert os.path.exists(os.path.join(target_dir, 'valid-export_nodes.jsonl.gz'))
+    assert os.path.exists(os.path.join(target_dir, 'valid-export_edges.jsonl.gz'))
+
+    jlt2 = JsonlTransformer()
+    jlt2.parse(os.path.join(target_dir, 'valid-export_nodes.jsonl'))
+    jlt2.parse(os.path.join(target_dir, 'valid-export_edges.jsonl'))
+
+    assert jlt2.graph.number_of_nodes() == 6
+    assert jlt2.graph.number_of_edges() == 5
+
+    jlt3 = JsonlTransformer()
+    jlt3.parse(os.path.join(target_dir, 'valid-export_nodes.jsonl.gz'), compression='gz')
+    jlt3.parse(os.path.join(target_dir, 'valid-export_edges.jsonl.gz'), compression='gz')
+
+    assert jlt3.graph.number_of_nodes() == 6
+    assert jlt3.graph.number_of_edges() == 5

--- a/tests/unit/test_kgx_utils.py
+++ b/tests/unit/test_kgx_utils.py
@@ -4,7 +4,7 @@ from bmt import Toolkit
 from kgx.curie_lookup_service import CurieLookupService
 from kgx.utils.kgx_utils import get_toolkit, get_curie_lookup_service, get_prefix_prioritization_map, \
     get_biolink_element, get_biolink_ancestors, generate_edge_key, contract, expand, camelcase_to_sentencecase, \
-    snakecase_to_sentencecase, sentencecase_to_snakecase, sentencecase_to_camelcase
+    snakecase_to_sentencecase, sentencecase_to_snakecase, sentencecase_to_camelcase, generate_uuid
 
 
 def test_get_toolkit():
@@ -114,3 +114,7 @@ def test_expand(query):
     # get the IRI
     assert iri == query[1]
 
+
+def test_generate_uuid():
+    s = generate_uuid()
+    assert s.startswith('urn:uuid:')

--- a/tests/unit/test_oban_rdf_transformer.py
+++ b/tests/unit/test_oban_rdf_transformer.py
@@ -166,6 +166,7 @@ def test_save2():
     assert e2t1['frequency_of_phenotype'] == 'HP:0040283'
     assert e2t1['dc_source'] == 'Orphanet:93262'
 
+    t1.set_property_types({'frequency_of_phenotype': 'uriorcurie', 'dc_source': 'uriorcurie'})
     t1.save(os.path.join(target_dir, 'oban-export.ttl'), output_format='ttl')
     t1.save(os.path.join(target_dir, 'oban-export.nt'), output_format='nt')
 

--- a/tests/unit/test_oban_rdf_transformer.py
+++ b/tests/unit/test_oban_rdf_transformer.py
@@ -136,7 +136,7 @@ def test_save2():
         'https://monarchinitiative.org/frequencyOfPhenotype'
     }
     predicate_mapping = {
-        'http://purl.org/dc/elements/1.1/source': 'dc_source',
+        'http://purl.org/dc/elements/1.1/source': 'source',
         'https://monarchinitiative.org/frequencyOfPhenotype': 'frequency_of_phenotype'
     }
     t1 = ObanRdfTransformer(curie_map=cmap)
@@ -156,7 +156,7 @@ def test_save2():
     assert e1t1['relation'] == 'RO:0000091'
     assert e1t1['type'] == 'OBAN:association'
     assert e1t1['has_evidence'] == 'ECO:0000501'
-    assert e1t1['dc_source'] == 'OMIM:166400'
+    assert e1t1['source'] == 'OMIM:166400'
 
     e2t1 = list(t1.graph.get_edge_data('Orphanet:93262', 'HP:0000505').values())[0]
     assert e2t1['subject'] == 'Orphanet:93262'
@@ -164,9 +164,9 @@ def test_save2():
     assert e2t1['relation'] == 'RO:0002200'
     assert e2t1['type'] == 'OBAN:association'
     assert e2t1['frequency_of_phenotype'] == 'HP:0040283'
-    assert e2t1['dc_source'] == 'Orphanet:93262'
+    assert e2t1['source'] == 'Orphanet:93262'
 
-    t1.set_property_types({'frequency_of_phenotype': 'uriorcurie', 'dc_source': 'uriorcurie'})
+    t1.set_property_types({'frequency_of_phenotype': 'uriorcurie', 'source': 'uriorcurie'})
     t1.save(os.path.join(target_dir, 'oban-export.ttl'), output_format='ttl')
     t1.save(os.path.join(target_dir, 'oban-export.nt'), output_format='nt')
 
@@ -187,7 +187,7 @@ def test_save2():
     assert e1t2['relation'] == 'RO:0000091'
     assert e1t2['type'] == 'biolink:Association'
     assert e1t2['has_evidence'] == 'ECO:0000501'
-    assert e1t2['dc_source'] == 'OMIM:166400'
+    assert e1t2['source'] == 'OMIM:166400'
 
     e2t2 = list(t2.graph.get_edge_data('Orphanet:93262', 'HP:0000505').values())[0]
     assert e2t2['subject'] == 'Orphanet:93262'
@@ -195,7 +195,7 @@ def test_save2():
     assert e2t2['relation'] == 'RO:0002200'
     assert e2t2['type'] == 'biolink:Association'
     assert e2t2['frequency_of_phenotype'] == 'HP:0040283'
-    assert e2t2['dc_source'] == 'Orphanet:93262'
+    assert e2t2['source'] == 'Orphanet:93262'
 
     t3 = ObanRdfTransformer(curie_map=cmap)
     t3.set_predicate_mapping(predicate_mapping)
@@ -213,7 +213,7 @@ def test_save2():
     assert e1t3['relation'] == 'RO:0000091'
     assert e1t3['type'] == 'biolink:Association'
     assert e1t3['has_evidence'] == 'ECO:0000501'
-    assert e1t3['dc_source'] == 'OMIM:166400'
+    assert e1t3['source'] == 'OMIM:166400'
 
     e2t3 = list(t3.graph.get_edge_data('Orphanet:93262', 'HP:0000505').values())[0]
     assert e2t3['subject'] == 'Orphanet:93262'
@@ -221,7 +221,7 @@ def test_save2():
     assert e2t3['relation'] == 'RO:0002200'
     assert e2t3['type'] == 'biolink:Association'
     assert e2t3['frequency_of_phenotype'] == 'HP:0040283'
-    assert e2t3['dc_source'] == 'Orphanet:93262'
+    assert e2t3['source'] == 'Orphanet:93262'
 
 
 def test_save3():

--- a/tests/unit/test_rdf_utils.py
+++ b/tests/unit/test_rdf_utils.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from rdflib import URIRef, Graph
 
-from kgx.utils.rdf_utils import infer_category, generate_uuid
+from kgx.utils.rdf_utils import infer_category
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 resource_dir = os.path.join(cwd, '../resources')
@@ -20,7 +20,3 @@ def test_infer_category(query):
     [c] = infer_category(query[0], graph)
     assert c == query[1]
 
-
-def test_generate_uuid():
-    s = generate_uuid()
-    assert s.startswith('urn:uuid:')


### PR DESCRIPTION
This PR,
- Adds support for exporting Neo4j compatible TSV via CLI
- Fix a bug in ObographJsonTransformer where category for organism was being inferred incorrectly
- Fix a bug in RdfTransformer where nodes properties were not being converted to IRIs
- Update `kgx merge` and `kgx transform` operations and their YAML configurations
- Generate UUIDs for all edges
- Add support for parsing and exporting Jsonlines
- Add Dockerfile
- Update tests and documentation
